### PR TITLE
Start Tweaks library refactor

### DIFF
--- a/steam-buddy
+++ b/steam-buddy
@@ -2,16 +2,16 @@
 import os
 import bottle
 import shutil
-from steam_buddy import server
+from steam_buddy.server import server
 from steam_buddy.config import RESOURCE_DIR, FTP_SERVER, UPLOADS_DIR
 
 if __name__ == '__main__':
-	if not os.environ.get("DISPLAY"):
-		os.environ["DISPLAY"] = ":0.0"
+    if not os.environ.get("DISPLAY"):
+        os.environ["DISPLAY"] = ":0.0"
 
-	if os.path.exists(UPLOADS_DIR):
-		shutil.rmtree(UPLOADS_DIR)
+    if os.path.exists(UPLOADS_DIR):
+        shutil.rmtree(UPLOADS_DIR)
 
-	os.chdir(RESOURCE_DIR)
-	FTP_SERVER.run()
-	bottle.run(app=server, host='0.0.0.0', port=8844)
+    os.chdir(RESOURCE_DIR)
+    FTP_SERVER.run()
+    bottle.run(app=server, host='0.0.0.0', port=8844)

--- a/steam-config
+++ b/steam-config
@@ -1,165 +1,156 @@
 #!/usr/bin/env python
 
-import os
 import vdf
 import time
 import yaml
 import shutil
 import urllib.request
-
-
-if 'XDG_DATA_HOME' in os.environ:
-	DATA_HOME = os.environ['XDG_DATA_HOME']
-else:
-	DATA_HOME = os.environ['HOME'] + '/.local/share'
-
-if 'XDG_CONFIG_HOME' in os.environ:
-	CONFIG_HOME = os.environ['XDG_CONFIG_HOME']
-else:
-	CONFIG_HOME = os.environ['HOME'] + '/.config'
-
-if 'XDG_CACHE_HOME' in os.environ:
-	CACHE_HOME = os.environ['XDG_CACHE_HOME']
-else:
-	CACHE_HOME = os.environ['HOME'] + '/.cache'
-
-MAIN_FILE  = DATA_HOME + '/steam-tweaks.yaml'
-LOCAL_FILE = CONFIG_HOME + '/steam-tweaks.yaml'
-SHORTCUT_COMPAT_DATA_FILE = CACHE_HOME + '/steam-shortcuts-compat.yaml'
-
-STEAM_DIR = DATA_HOME + '/Steam'
-if not os.path.isdir(STEAM_DIR):
-	os.makedirs(STEAM_DIR)
-
-STATIC_FILE = '/usr/share/steam-tweaks/steam-tweaks.yaml'
-if os.path.exists(STATIC_FILE) and not os.path.exists(MAIN_FILE):
-	shutil.copyfile(STATIC_FILE, MAIN_FILE)
+from steam_buddy.utils import SteamEnvironment
+from steam_buddy.utils import ensure_directory
+from steam_buddy.utils import ensure_directory_for_file
+from steam_buddy.utils import file_exists
 
 
 def load_steam_config(path):
-	if os.path.isfile(path):
-		data = vdf.load(open(path))
-	else:
-		data = vdf.VDFDict()
-		data['InstallConfigStore'] = { 'Software': { 'Valve': { 'Steam': {}}}}
+    if file_exists(path):
+        data = vdf.load(open(path))
+    else:
+        data = vdf.VDFDict()
+        data['InstallConfigStore'] = {'Software': {'Valve': {'Steam': {}}}}
 
-	steam = data['InstallConfigStore']['Software']['Valve']['Steam']
+    steam = data['InstallConfigStore']['Software']['Valve']['Steam']
 
-	if 'CompatToolMapping' not in steam:
-		steam['CompatToolMapping'] = {}
-	else:
-		stale_entries=[]
-        
-		for game in steam['CompatToolMapping']:
-			if 'name' in steam['CompatToolMapping'][game] and 'config' in steam['CompatToolMapping'][game]:
-				if steam['CompatToolMapping'][game]['name'] == '' and steam['CompatToolMapping'][game]['config'] == '':
-					stale_entries.append(game)
+    if 'CompatToolMapping' not in steam:
+        steam['CompatToolMapping'] = {}
+    else:
+        stale_entries = []
 
-		for entry in stale_entries:
-			del data['InstallConfigStore']['Software']['Valve']['Steam']['CompatToolMapping'][entry]
-	
-	return data
+        for game in steam['CompatToolMapping']:
+            if ('name' in steam['CompatToolMapping'][game] and
+                    'config' in steam['CompatToolMapping'][game]):
+                if (steam['CompatToolMapping'][game]['name'] == '' and
+                        steam['CompatToolMapping'][game]['config'] == ''):
+                    stale_entries.append(game)
+
+        for entry in stale_entries:
+            del steam['CompatToolMapping'][entry]
+
+    return data
 
 
 def load_steam_localconfig(path):
-	if os.path.isfile(path):
-		data = vdf.load(open(path))
-	else:
-		data = vdf.VDFDict()
-		data['UserLocalConfigStore'] = { 'Software': { 'Valve': { 'Steam': {}}}}
+    if file_exists(path):
+        data = vdf.load(open(path))
+    else:
+        data = vdf.VDFDict()
+        data['UserLocalConfigStore'] = {'Software': {'Valve': {'Steam': {}}}}
 
-	steam_input = data['UserLocalConfigStore']
-	if 'Apps' not in steam_input:
-		steam_input['Apps'] = {}
+    steam_input = data['UserLocalConfigStore']
+    if 'Apps' not in steam_input:
+        steam_input['Apps'] = {}
 
-	launch_options = data['UserLocalConfigStore']['Software']['Valve']['Steam']
-	if 'Apps' not in launch_options:
-		launch_options['Apps'] = {}
+    launch_options = data['UserLocalConfigStore']['Software']['Valve']['Steam']
+    if 'Apps' not in launch_options:
+        launch_options['Apps'] = {}
 
-	return data
+    return data
 
 
 def update_steam_config(tweaks_file, steam_data, priority):
-	if not os.path.isfile(tweaks_file):
-		return
+    if not file_exists(tweaks_file):
+        return
 
-	compat = steam_data['InstallConfigStore']['Software']['Valve']['Steam']['CompatToolMapping']
+    compat = steam_data['InstallConfigStore']['Software']['Valve']['Steam']['CompatToolMapping']
 
-	data = yaml.load(open(tweaks_file), Loader=yaml.FullLoader)
-	for key in data:
-		if key not in compat or 'Priority' not in compat[key] or int(compat[key]['Priority']) <= priority:
-			if 'compat_tool' in data[key]:
-				entry = {}
-				entry['name'] = data[key]['compat_tool']
-				if 'compat_config' in data[key]:
-					entry['config'] = data[key]['compat_config']
-				entry['Priority'] = priority
-				compat[key] = entry
+    data = yaml.load(open(tweaks_file), Loader=yaml.FullLoader)
+    for key in data:
+        if (key not in compat or
+                'Priority' not in compat[key] or
+                int(compat[key]['Priority']) <= priority):
+            if 'compat_tool' in data[key]:
+                entry = {}
+                entry['name'] = data[key]['compat_tool']
+                if 'compat_config' in data[key]:
+                    entry['config'] = data[key]['compat_config']
+                entry['Priority'] = priority
+                compat[key] = entry
 
 
 def update_steam_localconfig(tweaks_file, steam_data):
-	if not os.path.isfile(tweaks_file):
-		return
+    if not file_exists(tweaks_file):
+        return
 
-	steam_input_data = steam_data['UserLocalConfigStore']['Apps']
-	launch_options = steam_data['UserLocalConfigStore']['Software']['Valve']['Steam']['Apps']
+    steam_input_data = steam_data['UserLocalConfigStore']['Apps']
+    launch_options = steam_data['UserLocalConfigStore']['Software']['Valve']['Steam']['Apps']
 
-	data = yaml.load(open(tweaks_file), Loader=yaml.FullLoader)
-	for key in data:
-		if 'steam_input' in data[key] and data[key]['steam_input'] == 'enabled':
-			steam_input_data[key] = {
-				"UseSteamControllerConfig" : "2",
-				"SteamControllerRumble" : "-1",
-				"SteamControllerRumbleIntensity" : "320",
-				"EnableSCTenFootOverlayCheckNew" : "1"
-			}
+    data = yaml.load(open(tweaks_file), Loader=yaml.FullLoader)
+    for key in data:
+        if ('steam_input' in data[key] and
+                data[key]['steam_input'] == 'enabled'):
+            steam_input_data[key] = {
+                "UseSteamControllerConfig": "2",
+                "SteamControllerRumble": "-1",
+                "SteamControllerRumbleIntensity": "320",
+                "EnableSCTenFootOverlayCheckNew": "1"
+            }
 
-		if 'launch_options' in data[key]:
-			if key not in launch_options:
-				launch_options[key] = {}
-			launch_options[key]['LaunchOptions'] = data[key]['launch_options']
-
-
-attempts = 0
-while attempts < 5:
-	try:
-		urllib.request.urlretrieve('https://raw.githubusercontent.com/ChimeraOS/chimera/master/steam-tweaks.yaml', MAIN_FILE)
-		break
-	except:
-		print('failed to update tweaks file (attempt {})'.format(attempts+1))
-		time.sleep(2)
-		attempts += 1
+        if 'launch_options' in data[key]:
+            if key not in launch_options:
+                launch_options[key] = {}
+            launch_options[key]['LaunchOptions'] = data[key]['launch_options']
 
 
+def main():
+    se = SteamEnvironment()
+    ensure_directory(se.STEAM_DIR)
+    if (file_exists(se.STATIC_TWEAKS_FILE) and
+            not file_exists(se.MAIN_TWEAKS_FILE)):
+        shutil.copyfile(se.STATIC_TWEAKS_FILE,
+                        se.MAIN_TWEAKS_FILE)
 
-config_dir = STEAM_DIR + '/config'
-config_file = config_dir + '/config.vdf'
+    attempts = 0
+    while attempts < 5:
+        try:
+		    urllib.request.urlretrieve(
+                'https://raw.githubusercontent.com/ChimeraOS/chimera/master/steam-tweaks.yaml',
+                se.MAIN_TWEAKS_FILE)
+            break
+        except:
+            print('failed to update tweaks file (attempt {})'.format(attempts + 1))
+            time.sleep(2)
+            attempts += 1
 
-if not os.path.isdir(config_dir):
-	os.makedirs(config_dir)
+    ensure_directory_for_file(se.STEAM_CONFIG_FILE)
 
-config_data = load_steam_config(config_file)
+    config_data = load_steam_config(se.STEAM_CONFIG_FILE)
 
-update_steam_config(MAIN_FILE, config_data, 209) # add global entries if file exists
-update_steam_config(LOCAL_FILE, config_data, 229) # add local entries if file exists
-update_steam_config(SHORTCUT_COMPAT_DATA_FILE, config_data, 209) # add shortcut compat data
-vdf.dump(config_data, open(config_file, 'w'), pretty=True)
+    update_steam_config(se.MAIN_TWEAKS_FILE,
+                        config_data,
+                        209)  # add global entries if file exists
+    update_steam_config(se.LOCAL_TWEAKS_FILE,
+                        config_data,
+                        229)  # add local entries if file exists
+    update_steam_config(se.COMPAT_DATA_FILE,
+                        config_data,
+                        209)  # add shortcut compat data
+    vdf.dump(config_data, open(se.STEAM_CONFIG_FILE, 'w'), pretty=True)
+
+    for user_dir in se.STEAM_USER_DIRS:
+        config_file = user_dir + '/config/localconfig.vdf'
+
+        ensure_directory_for_file(config_file)
+
+        config_data = load_steam_localconfig(config_file)
+
+        # Add global entries if file exists
+        update_steam_localconfig(se.MAIN_TWEAKS_FILE,
+                                 config_data)
+        # Add local entries if file exists
+        update_steam_localconfig(se.LOCAL_TWEAKS_FILE,
+                                 config_data)
+
+        vdf.dump(config_data, open(config_file, 'w'), pretty=True)
 
 
-USERS_DIR = STEAM_DIR + '/userdata'
-for user_dir in os.listdir(USERS_DIR):
-	if user_dir == 'anonymous':
-		continue
-
-	config_dir = USERS_DIR + '/' + user_dir + '/config'
-	config_file = config_dir + '/localconfig.vdf'
-
-	if not os.path.isdir(config_dir):
-		os.makedirs(config_dir)
-
-	config_data = load_steam_localconfig(config_file)
-
-	update_steam_localconfig(MAIN_FILE, config_data) # add global entries if file exists
-	update_steam_localconfig(LOCAL_FILE, config_data) # add local entries if file exists
-
+if __name__ == '__main__':
 	vdf.dump(config_data, open(config_file, 'w'), pretty=True)

--- a/steam-config
+++ b/steam-config
@@ -5,7 +5,7 @@ import time
 import yaml
 import shutil
 import urllib.request
-from steam_buddy.utils import SteamEnvironment
+from steam_buddy.utils import BuddyContext
 from steam_buddy.utils import ensure_directory
 from steam_buddy.utils import ensure_directory_for_file
 from steam_buddy.utils import file_exists
@@ -101,7 +101,7 @@ def update_steam_localconfig(tweaks_file, steam_data):
 
 
 def main():
-    se = SteamEnvironment()
+    se = BuddyContext()
     ensure_directory(se.STEAM_DIR)
     if (file_exists(se.STATIC_TWEAKS_FILE) and
             not file_exists(se.MAIN_TWEAKS_FILE)):

--- a/steam-patch
+++ b/steam-patch
@@ -6,32 +6,19 @@ import shutil
 import filecmp
 import subprocess
 from inotify_simple import INotify, flags
-
-
-if 'XDG_DATA_HOME' in os.environ:
-	DATA_HOME = os.environ['XDG_DATA_HOME']
-else:
-	DATA_HOME = os.environ['HOME'] + '/.local/share'
-
-if 'XDG_CONFIG_HOME' in os.environ:
-	CONFIG_HOME = os.environ['XDG_CONFIG_HOME']
-else:
-	CONFIG_HOME = os.environ['HOME'] + '/.config'
-
-STATIC_FILE    = 'steam-tweaks.yaml'
-MAIN_FILE      = os.path.join(DATA_HOME, 'steam-tweaks.yaml')
-OVERRIDE_FILE  = os.path.join(CONFIG_HOME, 'steam-tweaks.yaml')
-STEAM_DIR      = os.path.join(DATA_HOME, 'Steam/steamapps/common')
-
-inotify = INotify()
-watch_flags = flags.CREATE | flags.MODIFY | flags.DELETE
-steam_dir = inotify.add_watch(STEAM_DIR, watch_flags)
+from steam_buddy import utils
 
 
 patches = {}
 watches = {}
+se = utils.SteamEnvironment()
+inotify = INotify()
+watch_flags = flags.CREATE | flags.MODIFY | flags.DELETE
+steam_dir = inotify.add_watch(se.STEAM_DIR, watch_flags)
+
+
 def apply_patch(game_dir):
-    if not os.path.exists(os.path.join(STEAM_DIR, game_dir)):
+    if not os.path.exists(os.path.join(se.STEAM_DIR, game_dir)):
         print('apply_patch dir not exists:', game_dir)
         return
 
@@ -40,28 +27,31 @@ def apply_patch(game_dir):
     for spec in patch_specs:
         if 'exec' in spec:
             cmd = spec['exec']
-            subprocess.call([ cmd ], shell=True, cwd=os.path.join(STEAM_DIR, game_dir))
+            subprocess.call([cmd],
+                            shell=True,
+                            cwd=os.path.join(se.STEAM_DIR, game_dir))
         elif 'copy' in spec:
             args = spec['copy']
-            dst = os.path.join(STEAM_DIR, game_dir, args['dst'])
+            dst = os.path.join(se.STEAM_DIR, game_dir, args['dst'])
             if not os.path.exists(dst) or not filecmp.cmp(args['src'], dst):
                 if os.path.exists(os.path.dirname(dst)):
                     print('command: copy', args['dst'])
                     shutil.copyfile(args['src'], dst)
 
+
 def start_watch(game_dir):
-    if not os.path.exists(os.path.join(STEAM_DIR, game_dir)):
+    if not os.path.exists(os.path.join(se.STEAM_DIR, game_dir)):
         print('start_watch dir not exists:', game_dir)
         return
 
     print('starting watch:', game_dir)
-    wd = inotify.add_watch(os.path.join(STEAM_DIR, game_dir), watch_flags)
+    wd = inotify.add_watch(os.path.join(se.STEAM_DIR, game_dir), watch_flags)
     watches[wd] = game_dir
     apply_patch(game_dir)
 
 
 def load_data(data_path):
-    if not os.path.exists(data_path):
+    if not utils.file_exists(data_path):
         return
 
     print('load_data:', data_path)
@@ -74,13 +64,19 @@ def load_data(data_path):
 
     data.clear()
 
-load_data(STATIC_FILE)
-load_data(MAIN_FILE)
-load_data(OVERRIDE_FILE)
 
-while True:
-    for event in inotify.read():
-        if event.wd == steam_dir and event.name in patches:
-            start_watch(event.name)
-        if event.wd in watches:
-            apply_patch(watches[event.wd])
+def main():
+    load_data(se.STATIC_TWEAKS_FILE)
+    load_data(se.MAIN_TWEAKS_FILE)
+    load_data(se.LOCAL_TWEAKS_FILE)
+
+    while True:
+        for event in inotify.read():
+            if event.wd == steam_dir and event.name in patches:
+                start_watch(event.name)
+            if event.wd in watches:
+                apply_patch(watches[event.wd])
+
+
+if __name__ == '__main__':
+    main()

--- a/steam-patch
+++ b/steam-patch
@@ -6,12 +6,13 @@ import shutil
 import filecmp
 import subprocess
 from inotify_simple import INotify, flags
-from steam_buddy import utils
+from steam_buddy.utils import BuddyContext
+from steam_buddy.utils import file_exists
 
 
 patches = {}
 watches = {}
-se = utils.SteamEnvironment()
+se = BuddyContext()
 inotify = INotify()
 watch_flags = flags.CREATE | flags.MODIFY | flags.DELETE
 steam_dir = inotify.add_watch(se.STEAM_DIR, watch_flags)
@@ -51,7 +52,7 @@ def start_watch(game_dir):
 
 
 def load_data(data_path):
-    if not utils.file_exists(data_path):
+    if not file_exists(data_path):
         return
 
     print('load_data:', data_path)

--- a/steam-shortcuts
+++ b/steam-shortcuts
@@ -6,9 +6,11 @@ import vdf
 import yaml
 import zlib
 from datetime import datetime, date
+from steam_buddy import utils
 
-STEAM_USER_DIRS = []
+
 compat_data = {}
+
 
 def yearsago(years):
     from_date = datetime.now().date()
@@ -18,11 +20,11 @@ def yearsago(years):
         return from_date.replace(month=2, day=28, year=from_date.year - years)
 
 
-TIME_WARP_TAG='Time Warp'
-TIME_WARP_DATE=None
-TIME_WARP=os.environ.get('TIME_WARP')
+TIME_WARP_TAG = 'Time Warp'
+TIME_WARP_DATE = None
+TIME_WARP = os.environ.get('TIME_WARP')
 if TIME_WARP:
-    TIME_WARP_DATE=yearsago(int(TIME_WARP)).isoformat()
+    TIME_WARP_DATE = yearsago(int(TIME_WARP)).isoformat()
 
 
 def get_banner_id(exe, name):
@@ -31,28 +33,32 @@ def get_banner_id(exe, name):
     full_64 = (high_32 << 32) | 0x02000000
     return full_64
 
+
 def get_compat_id(exe, name):
     crc_input = ''.join([exe, name])
     return (zlib.crc32(crc_input.encode('utf-8')) & 0xffffffff) | 0x80000000
+
 
 def get_shortcut_id(exe, name):
     return get_compat_id(exe, name) - 2**32
 
 
-"""
-Returns the shortcut dictionary of the given app_id. If not found returns {}
-"""
 def match_app_id(sc, app_id):
+    """Returns the shortcut dictionary of the given app_id.
+    If not found returns {}
+    """
     for s in sc:
         if 'appid' in sc[s] and sc[s]['appid'] == app_id:
             return sc[s]
     return {}
 
-"""
-Creates a new shrotcut dictionary to be written later on the shortcut file.
-If an application exists with the same app ID in the file, tries to update it.
-"""
+
 def create_shortcut(entry, steam_shortcuts):
+    """Creates a new shrotcut dictionary to be written later on the
+    shortcut file.
+    If an application exists with the same app ID in the file, tries
+    to update it.
+    """
     if 'name' not in entry:
         print('shortcut missing required field "name"; skipping')
         return
@@ -118,9 +124,10 @@ def create_shortcut(entry, steam_shortcuts):
         shortcut['tags'][str(t)] = tag
         t += 1
 
+    se = utils.SteamEnvironment()
     if 'banner' in entry:
         _, ext = os.path.splitext(entry['banner'])
-        for user_dir in STEAM_USER_DIRS:
+        for user_dir in se.STEAM_USER_DIRS:
             dst_dir = user_dir + '/config/grid/'
             if not os.path.isdir(dst_dir):
                 os.makedirs(dst_dir)
@@ -138,41 +145,13 @@ def create_shortcut(entry, steam_shortcuts):
 
     return shortcut
 
+
 def main():
-    # Initialize all directories and files
-    if 'XDG_CACHE_HOME' in os.environ:
-        CACHE_HOME = os.environ['XDG_CACHE_HOME']
-    else:
-        CACHE_HOME = os.environ['HOME'] + '/.cache'
-
-    COMPAT_DATA_FILE = CACHE_HOME + '/steam-shortcuts-compat.yaml'
-
-    if 'XDG_DATA_HOME' in os.environ:
-        DATA_HOME = os.environ['XDG_DATA_HOME']
-    else:
-        DATA_HOME = os.environ['HOME'] + '/.local/share'
-
-    DATA_HOME += '/'
-
-    if not os.path.isdir(DATA_HOME + 'steam-shortcuts'):
-        os.makedirs(DATA_HOME + 'steam-shortcuts')
-
-    SHORTCUT_DIRS = [ DATA_HOME + 'steam-shortcuts' ]
-
-    if os.path.isdir('/usr/share/steam-shortcuts'):
-        SHORTCUT_DIRS.append('/usr/share/steam-shortcuts')
-
-    STEAM_USER_BASE_DIR = DATA_HOME + 'Steam/userdata/'
-    for d in os.listdir(STEAM_USER_BASE_DIR):
-        if d == 'anonymous' or d == 'ac' or d == '0':
-            continue
-        path = STEAM_USER_BASE_DIR + d
-        if os.path.isdir(path):
-            STEAM_USER_DIRS.append(path)
+    se = utils.SteamEnvironment()
 
     # Don't scan user directories if there are no shortcuts to create
     data = []
-    for d in SHORTCUT_DIRS:
+    for d in se.SHORTCUT_DIRS:
         for f in os.listdir(d):
             y = open(d + '/' + f)
             dd = yaml.load(y, Loader=yaml.FullLoader)
@@ -187,12 +166,12 @@ def main():
         sys.exit(1)
 
     # Get current shortcuts for each user
-    for user_dir in STEAM_USER_DIRS:
+    for user_dir in se.STEAM_USER_DIRS:
         steam_shortcuts = {}
         file_path = user_dir + '/config/shortcuts.vdf'
-        STEAM_SHORTCUT_FILE = file_path
+        steam_shortcuts_file = file_path
         if os.path.isfile(file_path):
-            s = vdf.binary_load(open(STEAM_SHORTCUT_FILE, 'rb'))
+            s = vdf.binary_load(open(steam_shortcuts_file, 'rb'))
             if 'shortcuts' in s:
                 steam_shortcuts = s['shortcuts']
 
@@ -208,9 +187,11 @@ def main():
         out = {}
         out['shortcuts'] = shortcuts
         b = vdf.binary_dumps(out)
-        open(STEAM_SHORTCUT_FILE, 'wb').write(b)
+        open(steam_shortcuts_file, 'wb').write(b)
 
-    yaml.dump(compat_data, open(COMPAT_DATA_FILE, 'w'), default_flow_style=False)
+    yaml.dump(compat_data,
+              open(se.COMPAT_DATA_FILE, 'w'),
+              default_flow_style=False)
 
 
 main()

--- a/steam-shortcuts
+++ b/steam-shortcuts
@@ -6,7 +6,7 @@ import vdf
 import yaml
 import zlib
 from datetime import datetime, date
-from steam_buddy import utils
+from steam_buddy.utils import BuddyContext
 
 
 compat_data = {}
@@ -124,7 +124,7 @@ def create_shortcut(entry, steam_shortcuts):
         shortcut['tags'][str(t)] = tag
         t += 1
 
-    se = utils.SteamEnvironment()
+    se = BuddyContext()
     if 'banner' in entry:
         _, ext = os.path.splitext(entry['banner'])
         for user_dir in se.STEAM_USER_DIRS:
@@ -147,7 +147,7 @@ def create_shortcut(entry, steam_shortcuts):
 
 
 def main():
-    se = utils.SteamEnvironment()
+    se = BuddyContext()
 
     # Don't scan user directories if there are no shortcuts to create
     data = []

--- a/steam_buddy/__init__.py
+++ b/steam_buddy/__init__.py
@@ -1,1 +1,0 @@
-from steam_buddy.server import server

--- a/steam_buddy/config.py
+++ b/steam_buddy/config.py
@@ -1,5 +1,5 @@
 import os
-from steam_buddy.utils import SteamEnvironment
+from steam_buddy.utils import BuddyContext
 from steam_buddy.settings import Settings
 from steam_buddy.ftp.server import Server as FTPServer
 from steam_buddy.authenticator import Authenticator, generate_password
@@ -9,7 +9,7 @@ from steam_buddy.streaming import StreamServer
 from steam_buddy.mangohud_config import MangoHudConfig
 
 
-se = SteamEnvironment()
+se = BuddyContext()
 
 RESOURCE_DIR = os.getcwd()
 if not os.path.isfile(os.path.join(RESOURCE_DIR, 'views/base.tpl')):
@@ -19,6 +19,7 @@ AUTHENTICATOR_PATH = os.path.abspath('bin/steam-buddy-authenticator')
 if not os.path.isfile(AUTHENTICATOR_PATH):
     AUTHENTICATOR_PATH = "/usr/share/steam-buddy/bin/steam-buddy-authenticator"
 
+SHORTCUT_DIR = se.SHORTCUT_DIRS[0]
 BANNER_DIR = se.DATA_HOME + '/steam-buddy/banners'
 CONTENT_DIR = se.DATA_HOME + '/steam-buddy/content'
 RECORDINGS_DIR = se.DATA_HOME + '/steam-buddy/recordings'

--- a/steam_buddy/config.py
+++ b/steam_buddy/config.py
@@ -1,4 +1,5 @@
 import os
+from steam_buddy.utils import SteamEnvironment
 from steam_buddy.settings import Settings
 from steam_buddy.ftp.server import Server as FTPServer
 from steam_buddy.authenticator import Authenticator, generate_password
@@ -7,9 +8,8 @@ from steam_buddy.steamgrid.steamgrid import Steamgrid
 from steam_buddy.streaming import StreamServer
 from steam_buddy.mangohud_config import MangoHudConfig
 
-DATA_DIR = os.getenv('XDG_DATA_HOME', os.path.expanduser('~/.local/share'))
-CONFIG_DIR = os.getenv('XDG_CONFIG_HOME', os.path.expanduser('~/.config'))
-CACHE_DIR = os.getenv('XDG_CACHE_HOME', os.path.expanduser('~/.cache'))
+
+se = SteamEnvironment()
 
 RESOURCE_DIR = os.getcwd()
 if not os.path.isfile(os.path.join(RESOURCE_DIR, 'views/base.tpl')):
@@ -19,13 +19,12 @@ AUTHENTICATOR_PATH = os.path.abspath('bin/steam-buddy-authenticator')
 if not os.path.isfile(AUTHENTICATOR_PATH):
     AUTHENTICATOR_PATH = "/usr/share/steam-buddy/bin/steam-buddy-authenticator"
 
-SHORTCUT_DIR = DATA_DIR + '/steam-shortcuts'
-BANNER_DIR = DATA_DIR + '/steam-buddy/banners'
-CONTENT_DIR = DATA_DIR + '/steam-buddy/content'
-RECORDINGS_DIR = DATA_DIR + '/steam-buddy/recordings'
-SETTINGS_DIR = DATA_DIR + '/steam-buddy/settings'
-UPLOADS_DIR = os.path.join(CACHE_DIR, 'steam-buddy', 'uploads')
-MANGOHUD_DIR = CONFIG_DIR + "/MangoHud"
+BANNER_DIR = se.DATA_HOME + '/steam-buddy/banners'
+CONTENT_DIR = se.DATA_HOME + '/steam-buddy/content'
+RECORDINGS_DIR = se.DATA_HOME + '/steam-buddy/recordings'
+SETTINGS_DIR = se.DATA_HOME + '/steam-buddy/settings'
+UPLOADS_DIR = os.path.join(se.CACHE_HOME, 'steam-buddy', 'uploads')
+MANGOHUD_DIR = se.CONFIG_HOME + "/MangoHud"
 
 PLATFORMS = {
     "32x":         "32X",

--- a/steam_buddy/functions.py
+++ b/steam_buddy/functions.py
@@ -2,23 +2,30 @@ import re
 import os
 import shutil
 import yaml
-from steam_buddy.config import SHORTCUT_DIR
 from PIL import Image, ImageFont, ImageDraw
+from steam_buddy.utils import ensure_directory
+from steam_buddy.utils import file_exists
+from steam_buddy.utils import SteamEnvironment
 
 
 def sanitize(string):
     if isinstance(string, str):
-        return string.replace('\n', '_').replace('\r', '_').replace('/', '_').replace('\\', '_').replace('\0', '_').replace('"', '')
-
+        retval = string
+        for r in ['\n', '\r', '/', '\\', '\0']:
+            retval = retval.replace(r, '_')
+        retval.replace('"', '')
+        return retval
     return string
 
 
 def load_shortcuts(platform):
     shortcuts = []
-    if not os.path.exists(SHORTCUT_DIR):
-        os.makedirs(SHORTCUT_DIR)
-    shortcuts_file = "{shortcuts_dir}/steam-buddy.{platform}.yaml".format(shortcuts_dir=SHORTCUT_DIR, platform=platform)
-    if os.path.isfile(shortcuts_file):
+    se = SteamEnvironment()
+    ensure_directory(se.SHORTCUT_DIRS[0])
+
+    shortcuts_file = se.SHORTCUT_DIRS[0] + \
+        "/steam-buddy.{platform}.yaml".format(platform=platform)
+    if file_exists(shortcuts_file):
         shortcuts = yaml.load(open(shortcuts_file), Loader=yaml.Loader)
 
     if not shortcuts:

--- a/steam_buddy/functions.py
+++ b/steam_buddy/functions.py
@@ -5,7 +5,7 @@ import yaml
 from PIL import Image, ImageFont, ImageDraw
 from steam_buddy.utils import ensure_directory
 from steam_buddy.utils import file_exists
-from steam_buddy.utils import SteamEnvironment
+from steam_buddy.utils import BuddyContext
 
 
 def sanitize(string):
@@ -20,7 +20,7 @@ def sanitize(string):
 
 def load_shortcuts(platform):
     shortcuts = []
-    se = SteamEnvironment()
+    se = BuddyContext()
     ensure_directory(se.SHORTCUT_DIRS[0])
 
     shortcuts_file = se.SHORTCUT_DIRS[0] + \

--- a/steam_buddy/mangohud_config.py
+++ b/steam_buddy/mangohud_config.py
@@ -1,5 +1,7 @@
 import os
 from configparser import ConfigParser
+from steam_buddy.utils import ensure_directory_for_file
+from steam_buddy.utils import file_exists
 
 
 class MangoHudConfig:
@@ -10,7 +12,7 @@ class MangoHudConfig:
         self.__read_toggle_key()
 
     def __setup_environment(self):
-        if not os.path.exists(self.config_file):
+        if not file_exists(self.config_file):
             self.reset_config()
 
     def __read_toggle_key(self):
@@ -18,7 +20,7 @@ class MangoHudConfig:
         parser = ConfigParser(allow_no_value=True)
 
         # Check in file for override
-        if os.path.exists(self.config_file):
+        if file_exists(self.config_file):
             f = open(self.config_file, "r")
             parser.read_string("[Mangohud]\n" + f.read())
             f.close()
@@ -43,14 +45,14 @@ class MangoHudConfig:
         self.save_config("\n".join(defaultt_config))
 
     def get_current_config(self):
-        if os.path.exists(self.config_file):
+        if file_exists(self.config_file):
             f = open(self.config_file, "r")
             current_config = f.read()
             f.close()
             return current_config
 
     def save_config(self, new_content):
-        self.ensure_dir_for_file(self.config_file)
+        ensure_directory_for_file(self.config_file)
         f = open(self.config_file, "w+")
         f.write(new_content)
         f.close()
@@ -58,9 +60,3 @@ class MangoHudConfig:
 
     def get_toggle_hud_key(self):
         return self.toggle_key
-
-    @staticmethod
-    def ensure_dir_for_file(file):
-        d = os.path.dirname(file)
-        if not os.path.exists(d):
-            os.mkdir(d, mode=0o755)

--- a/steam_buddy/platforms/epic_store.py
+++ b/steam_buddy/platforms/epic_store.py
@@ -1,16 +1,27 @@
 import subprocess
 import json
 import os
-from steam_buddy.config import CONFIG_DIR, BANNER_DIR, CONTENT_DIR
+from steam_buddy.utils import SteamEnvironment
+from steam_buddy.utils import ensure_directory
+from steam_buddy.config import BANNER_DIR
+from steam_buddy.config import CONTENT_DIR
 from steam_buddy.platforms.store_platform import StorePlatform, dic
 
 
-METADATA_DIR = os.path.join(CONFIG_DIR, 'legendary', 'metadata')
 
 
 class EpicStore(StorePlatform):
+    def __init__(self):
+        se = SteamEnvironment()
+        self.METADATA_DIR = os.path.join(se.CONFIG_HOME,
+                                         'legendary',
+                                         'metadata')
+
     def is_authenticated(self):
-        return os.path.isfile(os.path.join(CONFIG_DIR, "legendary", "user.json"))
+        se = SteamEnvironment()
+        return os.path.isfile(os.path.join(se.CONFIG_HOME,
+                                           "legendary",
+                                           "user.json"))
 
     def authenticate(self, password):
         subprocess.check_output(["legendary", "auth", "--sid", password])
@@ -18,10 +29,7 @@ class EpicStore(StorePlatform):
     def get_shortcut(self, content):
         ext = '.jpg'
         base_path = os.path.join(BANNER_DIR, 'epic-store/')
-        try:
-            os.makedirs(base_path)
-        except:
-            pass
+        ensure_directory(base_path)
 
         img_path = base_path + content.content_id + ext
         subprocess.check_output(["curl", content.image_url, "-o", img_path])
@@ -44,7 +52,7 @@ class EpicStore(StorePlatform):
             if data[3] == 'True':  # exclude DLC
                 continue
 
-            with open(os.path.join(METADATA_DIR, data[0] + '.json')) as f:
+            with open(os.path.join(self.METADATA_DIR, data[0] + '.json')) as f:
                 metadata = json.load(f)
 
             for img in metadata['metadata']['keyImages']:
@@ -70,7 +78,7 @@ class EpicStore(StorePlatform):
             if data[0] in installed_ids:
                 continue
 
-            with open(os.path.join(METADATA_DIR, data[0]+'.json')) as f:
+            with open(os.path.join(self.METADATA_DIR, data[0]+'.json')) as f:
                 metadata = json.load(f)
 
             for img in metadata['metadata']['keyImages']:

--- a/steam_buddy/platforms/epic_store.py
+++ b/steam_buddy/platforms/epic_store.py
@@ -1,7 +1,7 @@
 import subprocess
 import json
 import os
-from steam_buddy.utils import SteamEnvironment
+from steam_buddy.utils import BuddyContext
 from steam_buddy.utils import ensure_directory
 from steam_buddy.config import BANNER_DIR
 from steam_buddy.config import CONTENT_DIR
@@ -12,13 +12,13 @@ from steam_buddy.platforms.store_platform import StorePlatform, dic
 
 class EpicStore(StorePlatform):
     def __init__(self):
-        se = SteamEnvironment()
+        se = BuddyContext()
         self.METADATA_DIR = os.path.join(se.CONFIG_HOME,
                                          'legendary',
                                          'metadata')
 
     def is_authenticated(self):
-        se = SteamEnvironment()
+        se = BuddyContext()
         return os.path.isfile(os.path.join(se.CONFIG_HOME,
                                            "legendary",
                                            "user.json"))

--- a/steam_buddy/platforms/gog.py
+++ b/steam_buddy/platforms/gog.py
@@ -1,20 +1,23 @@
 import subprocess
 import json
 import os
-import glob
 import shutil
 from io import BytesIO
-from steam_buddy.config import CACHE_DIR, CONFIG_DIR, BANNER_DIR, CONTENT_DIR
+from steam_buddy.utils import SteamEnvironment
+from steam_buddy.utils import ensure_directory
+from steam_buddy.utils import file_exists
+from steam_buddy.config import CONTENT_DIR
+from steam_buddy.config import BANNER_DIR
 from steam_buddy.platforms.store_platform import StorePlatform, dic
 from steam_buddy.functions import load_shortcuts
-
 
 
 class GOG(StorePlatform):
     def is_authenticated(self):
         num_lines = 0
-        path = os.path.join(CONFIG_DIR, "wyvern", "wyvern.toml")
-        if os.path.isfile(path):
+        se = SteamEnvironment()
+        path = os.path.join(se.CONFIG_HOME, "wyvern", "wyvern.toml")
+        if file_exists(path):
             num_lines = sum(1 for line in open(path))
 
         if num_lines > 1:
@@ -28,13 +31,10 @@ class GOG(StorePlatform):
     def get_shortcut(self, content):
         ext = '.png'
         base_path = os.path.join(BANNER_DIR, 'gog/')
-        try:
-            os.makedirs(base_path)
-        except:
-            pass
+        ensure_directory(base_path)
 
         img_path = base_path + content.content_id + ext
-        subprocess.check_output(["curl", content.image_url, "-o", img_path ])
+        subprocess.check_output(["curl", content.image_url, "-o", img_path])
 
         game_dir = os.path.join(CONTENT_DIR, 'gog', content.content_id)
 
@@ -85,15 +85,10 @@ class GOG(StorePlatform):
         pass
 
     def _install(self, content) -> subprocess:
-        cachedir = os.path.join(CACHE_DIR, 'steam-buddy')
-        try:
-            shutil.rmtree(cachedir)
-        except:
-            pass
-        try:
-            os.mkdir(cachedir)
-        except:
-            pass
+        se = SteamEnvironment()
+        cachedir = os.path.join(se.CACHE_HOME, 'steam-buddy')
+        shutil.rmtree(cachedir, ignore_errors=True)
+        ensure_directory(cachedir)
 
         if not content.native:
             cmd = ["bin/gog-install", content.content_id, os.path.join(CONTENT_DIR, 'gog', content.content_id)]

--- a/steam_buddy/platforms/gog.py
+++ b/steam_buddy/platforms/gog.py
@@ -3,7 +3,7 @@ import json
 import os
 import shutil
 from io import BytesIO
-from steam_buddy.utils import SteamEnvironment
+from steam_buddy.utils import BuddyContext
 from steam_buddy.utils import ensure_directory
 from steam_buddy.utils import file_exists
 from steam_buddy.config import CONTENT_DIR
@@ -15,7 +15,7 @@ from steam_buddy.functions import load_shortcuts
 class GOG(StorePlatform):
     def is_authenticated(self):
         num_lines = 0
-        se = SteamEnvironment()
+        se = BuddyContext()
         path = os.path.join(se.CONFIG_HOME, "wyvern", "wyvern.toml")
         if file_exists(path):
             num_lines = sum(1 for line in open(path))
@@ -85,7 +85,7 @@ class GOG(StorePlatform):
         pass
 
     def _install(self, content) -> subprocess:
-        se = SteamEnvironment()
+        se = BuddyContext()
         cachedir = os.path.join(se.CACHE_HOME, 'steam-buddy')
         shutil.rmtree(cachedir, ignore_errors=True)
         ensure_directory(cachedir)

--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -25,6 +25,7 @@ from steam_buddy.config import AUTHENTICATOR
 from steam_buddy.config import SETTINGS_HANDLER
 from steam_buddy.config import STEAMGRID_HANDLER
 from steam_buddy.config import FTP_SERVER
+from steam_buddy.config import SHORTCUT_DIR
 from steam_buddy.config import RESOURCE_DIR
 from steam_buddy.config import BANNER_DIR
 from steam_buddy.config import CONTENT_DIR

--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -10,10 +10,33 @@ import bcrypt
 import requests
 import shutil
 import unicodedata
-from bottle import app, route, template, static_file, redirect, abort, request, response
+from bottle import app
+from bottle import route
+from bottle import template
+from bottle import static_file
+from bottle import redirect
+from bottle import abort
+from bottle import request
+from bottle import response
 from beaker.middleware import SessionMiddleware
-from steam_buddy.config import PLATFORMS, SSH_KEY_HANDLER, AUTHENTICATOR, SETTINGS_HANDLER, STEAMGRID_HANDLER, FTP_SERVER, RESOURCE_DIR, BANNER_DIR, CONTENT_DIR, SHORTCUT_DIR, UPLOADS_DIR, SESSION_OPTIONS, STREAMING_HANDLER, MANGOHUD_HANDLER
-from steam_buddy.functions import load_shortcuts, sanitize, upsert_file, delete_file, generate_banner
+from steam_buddy.config import PLATFORMS
+from steam_buddy.config import SSH_KEY_HANDLER
+from steam_buddy.config import AUTHENTICATOR
+from steam_buddy.config import SETTINGS_HANDLER
+from steam_buddy.config import STEAMGRID_HANDLER
+from steam_buddy.config import FTP_SERVER
+from steam_buddy.config import RESOURCE_DIR
+from steam_buddy.config import BANNER_DIR
+from steam_buddy.config import CONTENT_DIR
+from steam_buddy.config import UPLOADS_DIR
+from steam_buddy.config import SESSION_OPTIONS
+from steam_buddy.config import STREAMING_HANDLER
+from steam_buddy.config import MANGOHUD_HANDLER
+from steam_buddy.functions import load_shortcuts
+from steam_buddy.functions import sanitize
+from steam_buddy.functions import upsert_file
+from steam_buddy.functions import delete_file
+from steam_buddy.functions import generate_banner
 from steam_buddy.auth_decorator import authenticate
 from steam_buddy.platforms.epic_store import EpicStore
 from steam_buddy.platforms.flathub import Flathub

--- a/steam_buddy/utils.py
+++ b/steam_buddy/utils.py
@@ -4,7 +4,7 @@ import os
 
 def ensure_directory(directory):
     if not os.path.isdir(directory):
-        os.mkdir(directory)
+        os.makedirs(directory, mode=0o755, exist_ok=True)
 
 
 def ensure_directory_for_file(file):
@@ -16,7 +16,7 @@ def file_exists(file):
     return os.path.exists(file)
 
 
-class SteamEnvironment:
+class BuddyContext:
     """Singleton class to manage the Steam environment.
     It contains variables and common functions to be used in all
     steam_buddy tools"""
@@ -25,7 +25,7 @@ class SteamEnvironment:
 
     def __new__(cls):
         if cls._instance is None:
-            cls._instance = super(SteamEnvironment, cls).__new__(cls)
+            cls._instance = super(BuddyContext, cls).__new__(cls)
             cls._instance.__init()
         return cls._instance
 
@@ -82,6 +82,7 @@ class SteamEnvironment:
 
     def __get_steam_user_dirs(self):
         base = self.STEAM_DIR + '/userdata'
+        ensure_directory(base)
         user_dirs = []
         for d in os.listdir(base):
             if d not in ['anonymous', 'ac', '0']:

--- a/steam_buddy/utils.py
+++ b/steam_buddy/utils.py
@@ -1,0 +1,97 @@
+"""Utilities for the steam_buddy tools"""
+import os
+
+
+def ensure_directory(directory):
+    if not os.path.isdir(directory):
+        os.mkdir(directory)
+
+
+def ensure_directory_for_file(file):
+    d = os.path.dirname(file)
+    ensure_directory(d)
+
+
+def file_exists(file):
+    return os.path.exists(file)
+
+
+class SteamEnvironment:
+    """Singleton class to manage the Steam environment.
+    It contains variables and common functions to be used in all
+    steam_buddy tools"""
+
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(SteamEnvironment, cls).__new__(cls)
+            cls._instance.__init()
+        return cls._instance
+
+    def __init(self):
+        """Initialize all directories and common file names"""
+        self.CACHE_HOME = self.__get_cache_home_dir()
+        self.CONFIG_HOME = self.__get_config_home_dir()
+        self.DATA_HOME = self.__get_data_home_dir()
+        self.COMPAT_DATA_FILE = self.__get_compat_data_file()
+        self.SHORTCUT_DIRS = self.__get_shortcut_dirs()
+        self.STEAM_DIR = self.__get_steam_dir()
+        self.STEAM_APPS_DIR = self.__get_steam_apps_dir()
+        self.STEAM_USER_DIRS = self.__get_steam_user_dirs()
+        self.STATIC_TWEAKS_FILE = self.__get_static_tweaks_file()
+        self.MAIN_TWEAKS_FILE = self.__get_main_tweaks_file()
+        self.LOCAL_TWEAKS_FILE = self.__get_local_tweaks_file()
+
+    def __get_cache_home_dir(self):
+        if 'XDG_CACHE_HOME' in os.environ:
+            cache = os.environ['XDG_CACHE_HOME']
+        else:
+            cache = os.environ['HOME'] + '/.cache'
+        return cache
+
+    def __get_config_home_dir(self):
+        if 'XDG_CONFIG_HOME' in os.environ:
+            config = os.environ['XDG_CONFIG_HOME']
+        else:
+            config = os.environ['HOME'] + '/.config'
+        return config
+
+    def __get_data_home_dir(self):
+        if 'XDG_DATA_HOME' in os.environ:
+            data_home = os.environ['XDG_CACHE_HOME']
+        else:
+            data_home = os.environ['HOME'] + '/.local/share'
+        return data_home
+
+    def __get_compat_data_file(self):
+        return self.CACHE_HOME + '/steam-shortcuts-compat.yaml'
+
+    def __get_shortcut_dirs(self):
+        shortcut_dirs = [self.DATA_HOME + '/steam-shortcuts']
+        if os.path.isdir('/usr/share/steam-shortcuts'):
+            shortcut_dirs.append('/usr/share/steam-shortcuts')
+        return shortcut_dirs
+
+    def __get_steam_dir(self):
+        return self.DATA_HOME + '/Steam'
+
+    def __get_steam_apps_dir(self):
+        return self.STEAM_DIR + '/steamapps/common'
+
+    def __get_steam_user_dirs(self):
+        base = self.STEAM_DIR + '/userdata'
+        user_dirs = []
+        for d in os.listdir(base):
+            if d not in ['anonymous', 'ac', '0']:
+                user_dirs.append('/'.join([base, d]))
+        return user_dirs
+
+    def __get_main_tweaks_file(self):
+        return self.DATA_HOME + '/steam-tweaks.yaml'
+
+    def __get_local_tweaks_file(self):
+        return self.CONFIG_HOME + '/steam-tweaks.yaml'
+
+    def __get_static_tweaks_file(self):
+        return '/usr/share/steam-tweaks/steam-tweaks.yaml'

--- a/steam_buddy/utils.py
+++ b/steam_buddy/utils.py
@@ -39,6 +39,7 @@ class SteamEnvironment:
         self.STEAM_DIR = self.__get_steam_dir()
         self.STEAM_APPS_DIR = self.__get_steam_apps_dir()
         self.STEAM_USER_DIRS = self.__get_steam_user_dirs()
+        self.STEAM_CONFIG_FILE = self.__get_steam_config_file()
         self.STATIC_TWEAKS_FILE = self.__get_static_tweaks_file()
         self.MAIN_TWEAKS_FILE = self.__get_main_tweaks_file()
         self.LOCAL_TWEAKS_FILE = self.__get_local_tweaks_file()
@@ -86,6 +87,9 @@ class SteamEnvironment:
             if d not in ['anonymous', 'ac', '0']:
                 user_dirs.append('/'.join([base, d]))
         return user_dirs
+
+    def __get_steam_config_file(self):
+        return self.STEAM_DIR + '/config/config.vdf'
 
     def __get_main_tweaks_file(self):
         return self.DATA_HOME + '/steam-tweaks.yaml'

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,6 +1,6 @@
 import os
 from webtest import TestApp
-from steam_buddy import server
+from steam_buddy.server import server
 from steam_buddy.config import PLATFORMS, AUTHENTICATOR_PATH
 
 


### PR DESCRIPTION
Add a `utils` module inside buddy for common functions and utilities used in all the toolset.
Use the module in `-shortcuts`, `-patch` and `-config` and `-buddy` tools without altering functionality.

- Added a `BuddyContext` object meant to contain common locations for files and directories used by the buddy toolset.
- Added `ensure_directory`, `ensure_directory_for_file` and `file_exists` functions for better abstraction of common file/directory creation tasks
- Convert `steam_buddy.server` to a module.
- Retab all edited files to [4 spaces](https://pep8.org/#indentation)

Edit: this branch will be rebased to master so the change is clean each time.