### PR TITLE
Add basic suspend, reboot and power system off

### DIFF
--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -705,6 +705,24 @@ def exit_game():
         redirect('/')
 
 
+@route('/reboot')
+@authenticate
+def reboot_system():
+    os.system('reboot')
+
+
+@route('/poweroff')
+@authenticate
+def poweroff_system():
+    os.system('poweroff')
+
+
+@route('/suspend')
+@authenticate
+def suspend_system():
+    os.system('systemctl suspend')
+
+
 def get_audio():
     if not shutil.which('ponymix'):
         return None


### PR DESCRIPTION
Three routes are given with no access from the menu for further
integration in the retooling/redesign of the web UI.

 - `/reboot` will reboot instantly the system provided no other user is
   logged in to the system (should be the default in GamerOS)
 - `/poweroff` will power the system off instantly provided no other
   user is logged in to the system.
 - `/suspend` will suspend the system.

Hibernation is a bit tricky. The functionality is not supported by most
systems and is highly hardware dependent.

This is mean to implement the feature proposed in #127. Can and should be complemented with an auto-suspend by means of [logind daemon](https://wiki.archlinux.org/title/Power_management#Power_management_with_systemd) by setting the appropriate `IdleAction` and `IdleActionSec` parameters.