### PR TITLE
Remove dx12 hack on F1 2020 using proton 6.3

### DIFF
--- a/steam-tweaks.yaml
+++ b/steam-tweaks.yaml
@@ -435,7 +435,6 @@
 
 "1080110": # F1 2020
   compat_tool: proton_63
-  compat_config: seccomp
 
 "995980": # Fae Tactics 
   compat_tool: proton_513

--- a/steam-tweaks.yaml
+++ b/steam-tweaks.yaml
@@ -436,7 +436,6 @@
 "1080110": # F1 2020
   compat_tool: proton_63
   compat_config: seccomp
-  launch_options: rm -f F1_2020_dx12.exe && ln -s F1_2020.exe F1_2020_dx12.exe; %command%
 
 "995980": # Fae Tactics 
   compat_tool: proton_513


### PR DESCRIPTION
May be useful in other games as well.

Tested on AMD by disabling all tweaks applied, Verifying the game data (thus redownloading the dx12 binary) and starting the game selecting "DX12 (Win 10 only)" option in launcher.