### PR TITLE
Add Age of Empires 2 (2013)

### DIFF
--- a/steam-tweaks.yaml
+++ b/steam-tweaks.yaml
@@ -34,6 +34,9 @@
 "331870": # AER Memories of Old; fix black screen in native version
   launch_options: '%command% -screen-fullscreen 0'
 
+"221380": # Age of Empires II (2013)
+  compat_tool: proton_411
+
 "1210150": # Ageless
   compat_tool: proton_513
 


### PR DESCRIPTION
Works with 4.11 well but newer versions introduced some glitches to the game.