### PR TITLE
Fix test failing with GOG

### DIFF
--- a/tests/test_server_functions.py
+++ b/tests/test_server_functions.py
@@ -41,7 +41,7 @@ def test_platform():
 
 def test_new():
     for p in PLATFORMS:
-        if p != 'epic-store' and p != 'flathub':
+        if p not in ['epic-store', 'flathub', 'gog']:
             document = new(p)
             validate_html("new({})".format(p), document)
 

--- a/views/custom_login.tpl
+++ b/views/custom_login.tpl
@@ -3,7 +3,7 @@
 % if platform == 'epic-store':
 <p class="platform-login-description">Please <a target="_blank" href="https://www.epicgames.com/id/login?redirectUrl=https://www.epicgames.com/id/api/redirect">login to the Epic Games Store</a> and paste the sid value that appears below.</p>
 % elif platform == 'gog':
-<p class="platform-login-description">Please <a target="_blank" href="https://login.gog.com/auth?client_id=46899977096215655&layout=client2%22&redirect_uri=https%3A%2F%2Fembed.gog.com%2Fon_login_success%3Forigin%3Dclient&response_type=code">login to GOG</a>. A blank page will appear with a code in the address bar after "code=". Paste the code from the address bar into the input box below.</p>
+<p class="platform-login-description">Please <a target="_blank" href="https://login.gog.com/auth?client_id=46899977096215655%26layout=client2%22%26redirect_uri=https%3A%2F%2Fembed.gog.com%2Fon_login_success%3Forigin%3Dclient%26response_type=code">login to GOG</a>. A blank page will appear with a code in the address bar after "code=". Paste the code from the address bar into the input box below.</p>
 % end
 
 <form action="/platforms/{{platform}}/authenticate" method="post" enctype="multipart/form-data">


### PR DESCRIPTION
Fixes errors on tests for the platform

- Fixed an escaping issue with `&` in the GOG login page
- Exclude GOG platform from the test_new test since is not authenticated