### PR TITLE
Remove `seccomp` from F1 2020

### DIFF
--- a/steam-tweaks.yaml
+++ b/steam-tweaks.yaml
@@ -450,7 +450,6 @@
 
 "1080110": # F1 2020
   compat_tool: proton_63
-  compat_config: seccomp
   launch_options: rm -f F1_2020_dx12.exe && ln -s F1_2020.exe F1_2020_dx12.exe; %command%
   
 "995980": # Fae Tactics 


### PR DESCRIPTION
It's not needed and deprecated in Proton > 5.0