### PR TITLE
Add basic chimera CLI for tweaks

### DIFF
--- a/chimera
+++ b/chimera
@@ -1,17 +1,3 @@
-#!/usr/bin/env python3
-import os
-import bottle
-import shutil
-from chimera_app.server import server
-from chimera_app.config import RESOURCE_DIR, FTP_SERVER, UPLOADS_DIR
+#!/bin/bash
 
-if __name__ == '__main__':
-    if not os.environ.get("DISPLAY"):
-        os.environ["DISPLAY"] = ":0.0"
-
-    if os.path.exists(UPLOADS_DIR):
-        shutil.rmtree(UPLOADS_DIR)
-
-    os.chdir(RESOURCE_DIR)
-    FTP_SERVER.run()
-    bottle.run(app=server, host='0.0.0.0', port=8844)
+python -m chimera_app "$@"

--- a/chimera_app/__main__.py
+++ b/chimera_app/__main__.py
@@ -1,0 +1,71 @@
+import os
+import shutil
+import argparse
+import bottle
+from chimera_app.server import server
+from chimera_app.compat_tools import install_all_compat_tools
+from chimera_app.shortcuts import create_all_shortcuts
+from chimera_app.steam_config import apply_all_tweaks
+from chimera_app.config import RESOURCE_DIR, FTP_SERVER, UPLOADS_DIR
+
+
+def setup_argparse():
+    parser = argparse.ArgumentParser(
+        description='Chimera app for managing ChimeraOS')
+
+    group_ex = parser.add_mutually_exclusive_group()
+    group_ex.add_argument('-d', '--daemon',
+                          action="store_true",
+                          help='Start chimera app web server (default behaviour)'
+                          )
+    group_ex.add_argument('-t', '--tweaks',
+                          action="store_true",
+                          help='Download and apply all tweaks'
+                          )
+    group_ex.add_argument('-c', '--compat',
+                          action="store_true",
+                          help='Generate stubs for compatibility tools'
+                          )
+    group_ex.add_argument('-s', '--shortcuts',
+                          action="store_true",
+                          help='Read shortcuts files and add them to Steam'
+                          )
+    group_ex.add_argument('-g', '--config',
+                          action="store_true",
+                          help='Download tweak file and apply configuration for Steam games'
+                          )
+
+    return parser.parse_args()
+
+
+def run_server():
+    if not os.environ.get("DISPLAY"):
+        os.environ["DISPLAY"] = ":0.0"
+
+    if os.path.exists(UPLOADS_DIR):
+        shutil.rmtree(UPLOADS_DIR)
+
+    os.chdir(RESOURCE_DIR)
+    FTP_SERVER.run()
+    bottle.run(app=server, host='0.0.0.0', port=8844)
+
+
+def main():
+    args = setup_argparse()
+    if (args.daemon or
+    not (args.daemon or args.compat or args.shortcuts or args.config or args.tweaks)):
+        run_server()
+    if args.compat:
+        install_all_compat_tools()
+    if args.shortcuts:
+        create_all_shortcuts()
+    if args.config:
+        apply_all_tweaks()
+    if args.tweaks:
+        install_all_compat_tools()
+        create_all_shortcuts()
+        apply_all_tweaks()
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,19 @@
-from setuptools import setup, find_packages
+"Setup chimera app"
 from glob import glob
+from setuptools import setup, find_packages
 
 setup(
     name="Chimera",
     version="0.11.0",
     packages=find_packages(exclude=['tests']),
-    scripts=['chimera',
-             'migrate-to-chimera',
+    entry_points={
+        'console_scripts': ['chimera = chimera_app.__main__:main']
+                  },
+    scripts=['migrate-to-chimera',
              'steam-tweaks',
-             'steam-compat-tool-stubs',
-             'steam-shortcuts',
-             'steam-config',
              'steam-patch',
              'tweaks-mfplat'
-            ],
+             ],
 
     data_files=[
         ('share/chimera/images', glob('images/*.png')),
@@ -48,12 +48,16 @@ setup(
     # metadata to display on PyPI
     author="Alesh Slovak",
     author_email="aleshslovak@gmail.com",
-    description="Chimera is a web based tool for installing non-Steam software to your Linux based couch gaming system. It was primarily developed for ChimeraOS.",
-    keywords="steam steamos couch emulation flatpak flathub chimera app chimeraos gamer gaming",
+    description=("Chimera is a web based tool for installing non-Steam "
+                 "software to your Linux based couch gaming system. It "
+                 "was primarily developed for ChimeraOS."),
+    keywords=("steam steamos couch emulation flatpak flathub chimera app "
+              "chimeraos gamer gaming"),
     url="https://github.com/chimeraos/chimera",   # project home page, if any
     project_urls={
         "Bug Tracker": "https://github.com/chimeraos/chimera/issues",
-        "Documentation": "https://github.com/chimeraos/chimera/blob/master/README.md",
+        "Documentation": ("https://github.com/chimeraos/chimera/"
+                          "blob/master/README.md"),
         "Source Code": "https://github.com/chimeraos/chimera",
     },
     classifiers=[

--- a/steam-compat-tool-stubs
+++ b/steam-compat-tool-stubs
@@ -1,6 +1,0 @@
-#!/usr/bin/env python
-
-from chimera_app.compat_tools import install_all_compat_tools
-
-
-install_all_compat_tools()

--- a/steam-config
+++ b/steam-config
@@ -1,6 +1,0 @@
-#!/usr/bin/env python
-
-from chimera_app.steam_config import apply_all_tweaks
-
-
-apply_all_tweaks()

--- a/steam-shortcuts
+++ b/steam-shortcuts
@@ -1,6 +1,0 @@
-#!/usr/bin/env python
-
-from chimera_app.shortcuts import create_all_shortcuts
-
-
-create_all_shortcuts()

--- a/steam-tweaks
+++ b/steam-tweaks
@@ -1,6 +1,4 @@
 #! /bin/bash
 
 migrate-to-chimera --logout
-steam-compat-tool-stubs
-steam-shortcuts
-steam-config
+chimera --tweaks


### PR DESCRIPTION
Add simple CLI to chimera app to replace tweaks (and remove the scripts)

- `--daemon` will run the server as usual (no argument given will have the same effect)
- `--config`, `--compat` and `--shortcuts` will apply the same as their script counterparts.
- `--tweaks` will do the same as the last three (same as it script counterpart)

Currently `steam-tweaks` is needed for running migration script. But if it is integrated in another way the script can be deleted.