### PR TITLE
Integration tests and some fixes for them

### DIFF
--- a/chimera_app/steam_config.py
+++ b/chimera_app/steam_config.py
@@ -24,7 +24,8 @@ class SteamConfig:
         sc.apply_tweaks()
     """
 
-    _context = ChimeraContext()
+    def __init__(self):
+        self._context = ChimeraContext()
 
     def update(self):
         self.download_tweaks_file(self._context.MAIN_TWEAKS_FILE,
@@ -63,7 +64,9 @@ class SteamConfig:
 
     @staticmethod
     def write(config_data, config_file):
-        vdf.dump(config_data, open(config_file, 'w'), pretty=True)
+        conf = vdf.dumps(config_data, pretty=True)
+        with open(config_file, 'w') as file:
+            file.write(conf)
 
     @staticmethod
     def load_main(path):
@@ -197,4 +200,3 @@ class SteamConfig:
                 if key not in launch_options:
                     launch_options[key] = {}
                 launch_options[key]['LaunchOptions'] = data[key]['launch_options']
-

--- a/chimera_app/utils.py
+++ b/chimera_app/utils.py
@@ -86,7 +86,7 @@ class ChimeraContext:
 
     def __get_data_home_dir(self):
         if 'XDG_DATA_HOME' in os.environ:
-            data_home = os.environ['XDG_CACHE_HOME']
+            data_home = os.environ['XDG_DATA_HOME']
         else:
             data_home = os.environ['HOME'] + '/.local/share'
         return data_home
@@ -122,7 +122,7 @@ class ChimeraContext:
         return self.STEAM_DIR + '/config/config.vdf'
 
     def __get_main_tweaks_file(self):
-        return self.DATA_HOME + '/steam-tweaks.yaml'
+        return self.DATA_HOME + '/chimera/steam-tweaks.yaml'
 
     def __get_local_tweaks_file(self):
         return self.CONFIG_HOME + '/steam-tweaks.yaml'

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -13,3 +13,4 @@ vdf
 pytest
 pytidylib
 requests-mock
+pyfakefs

--- a/tests/files/steam-tweaks.yaml
+++ b/tests/files/steam-tweaks.yaml
@@ -1,0 +1,14 @@
+"285820": # Action Henk
+  launch_options: LD_LIBRARY_PATH= %command%
+  steam_input: enabled
+
+"331870": # AER Memories of Old; fix black screen in native version
+  launch_options: '%command% -screen-fullscreen 0'
+
+"221380": # Age of Empires II (2013)
+  compat_tool: proton_411
+
+"409710": # BioShock Remastered
+  compat_tool: proton_513
+  compat_config: noesync,nofsync
+  launch_options: -nointro

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,91 @@
+"Integration tests for our scripts"
+
+import time
+import os
+import pytest
+import vdf
+from chimera_app.steam_config import SteamConfig as SC
+from chimera_app.steam_config import apply_all_tweaks
+from chimera_app.compat_tools import install_all_compat_tools
+from chimera_app.utils import ChimeraContext as CC
+
+
+@pytest.fixture
+def fake_data(monkeypatch,
+              fs):
+    files_path = os.path.join(os.path.dirname(__file__), 'files')
+
+    fs.add_real_file(os.path.join(files_path, 'steam-tweaks.yaml'),
+                     target_path='/usr/share/chimera/steam-tweaks.yaml')
+    fs.add_real_file(os.path.join(files_path,
+                                  '..',
+                                  '..',
+                                  'steam-compat-tool-stub.tpl'),
+                     target_path='/usr/share/chimera/steam-compat-tool-stub.tpl')
+    fs.add_real_directory(os.path.join(files_path,
+                                       '..',
+                                       '..',
+                                       'compat-tools',
+                                       'Proton-6.10-GE-1'),
+                          target_path='/usr/share/chimera/compat-tools/Proton-6.10-GE-1')
+    fs.create_dir(os.path.expanduser('~/.local/share/chimera'))
+    fs.create_dir(os.path.expanduser('~/.local/share/Steam/config'))
+    fs.create_dir(os.path.expanduser('~/.local/share/Steam/userdata/user-id/'))
+
+    yield fs
+
+
+def test_config_static(monkeypatch,
+                       requests_mock,
+                       fake_data):
+    "Test effects of tweaks with static file"
+
+    url = ('https://raw.githubusercontent.com/ChimeraOS/'
+           'chimera/master/steam-tweaks.yaml')
+    tweaks_file = os.path.expanduser(
+        '~/.local/share/chimera/steam-tweaks.yaml')
+    static_file = '/usr/share/chimera/steam-tweaks.yaml'
+
+    config_file = os.path.expanduser(
+        '~/.local/share/Steam/config/config.vdf')
+    user_config_file = os.path.expanduser(
+        '~/.local/share/Steam/userdata/user-id/config/localconfig.vdf')
+
+    monkeypatch.setattr(time, 'sleep', lambda s: None)
+    requests_mock.get(url, status_code=404)
+
+    apply_all_tweaks()
+
+    assert(os.path.exists(tweaks_file))
+    assert(open(tweaks_file).read() == open(static_file).read())
+
+    assert(os.path.exists(config_file))
+    conf_vdf = vdf.load(open(config_file))
+    compat = conf_vdf['InstallConfigStore']['Software']['Valve']['Steam']['CompatToolMapping']
+    assert(compat['221380']['name'] == 'proton_411')
+    assert(compat['409710']['name'] == 'proton_513')
+    assert(compat['409710']['config'] == 'noesync,nofsync')
+
+    assert(os.path.exists(user_config_file))
+    conf_vdf = vdf.load(open(user_config_file))
+    launch_options = conf_vdf['UserLocalConfigStore']['Software']['Valve']['Steam']['Apps']
+    assert(launch_options['285820']['LaunchOptions'] == 'LD_LIBRARY_PATH= %command%')
+    assert(launch_options['331870']['LaunchOptions'] == '%command% -screen-fullscreen 0')
+    assert(launch_options['409710']['LaunchOptions'] == '-nointro')
+
+    steam_input = conf_vdf['UserLocalConfigStore']['Apps']
+    assert(steam_input['285820']['UseSteamControllerConfig'] == '2')
+
+
+def test_compat_static(fake_data):
+    "Test compat-tools installation effects"
+    compat_tools_dir = os.path.expanduser(
+        '~/.local/share/Steam/compatibilitytools.d')
+    proton_ge_dir = os.path.join(compat_tools_dir, 'Proton-6.10-GE-1')
+
+    install_all_compat_tools()
+
+    assert(os.path.exists(proton_ge_dir))
+    assert(os.path.exists(os.path.join(proton_ge_dir, 'proton')))
+    assert(os.path.exists(os.path.join(proton_ge_dir, 'toolmanifest.vdf')))
+    assert(os.path.exists(os.path.join(proton_ge_dir, 'compatibilitytool.vdf')))

--- a/tests/test_steam_config.py
+++ b/tests/test_steam_config.py
@@ -1,4 +1,5 @@
 import os
+import time
 import tempfile
 import pytest
 import vdf
@@ -133,8 +134,10 @@ def tweaks_url_content(requests_mock,
 
 @pytest.fixture
 def tweaks_not_found(requests_mock,
+                     monkeypatch,
                      tweaks_url):
     """Mock a 404 code when searching for the tweaks file online"""
+    monkeypatch.setattr(time, 'sleep', lambda s: None)
     requests_mock.get(tweaks_url, status_code=404)
 
 


### PR DESCRIPTION
Because integration should be tested as well.

![GLaDOS](https://upload.wikimedia.org/wikipedia/en/b/bf/Glados.png)

Add `pyfakefs` for faking a filesystem
Add `compat_tools` and `steam_config` integration tests
Fix some broken paths and functions.