### PR TITLE
Tweaks refactor to install official Proton versions

### DIFF
--- a/chimera_app/compat_tools.py
+++ b/chimera_app/compat_tools.py
@@ -2,78 +2,152 @@
 
 import os
 import shutil
+from abc import ABC
+from abc import abstractmethod
 import chimera_app.context as context
 from chimera_app.utils import ensure_directory
 from chimera_app.utils import replace_all
+from chimera_app.utils import client_running
+from chimera_app.utils import install_by_id
 
 
-def install_all_compat_tools():
+# Hardcode this for now (taken from setamdb.info),
+# should be read from downloaded data.
+OFFICIAL_COMPAT_TOOLS = {
+    "proton_37":            "858280",
+    "proton_37_beta":       "930400",
+    "proton_316":           "961940",
+    "proton_316_beta":      "996510",
+    "proton_42":            "1054830",
+    "proton_411":           "1113280",
+    "proton_5":             "1245040",
+    "proton_513":           "1420170",
+    "proton_experimental":  "1493710",
+    "proton_63":            "1580130"
+}
+
+
+def install_all_compat_tools() -> bool:
+    """Install all external compatibility tools downloaded by chimera.
+    If there are no compatibility tools to install or the stub template is
+    missing this will take no action.
+
+    Tools are installed in a lazy way leaving a stub for the real install
+    process to begin when the tool is needed (at first run with a game that
+    uses it). If a tool is found with the same name already installed it will
+    take no action.
+
+    Returns True if sucessful or False if there are no tools to install.
+    """
     tools_dir = context.TOOLS_DIR
-    stub_file = os.path.join(tools_dir, 'tool-stub.tpl')
+    stub_tpl_path = os.path.join(tools_dir, 'tool-stub.tpl')
     if (not os.path.isdir(tools_dir)
-            or (not os.path.isfile(stub_file))):
+            or (not os.path.isfile(stub_tpl_path))):
         print(f'No tools to install from {tools_dir} or missing stub template')
-        return
+        return False
 
-    ensure_directory(context.STEAM_COMPAT_TOOLS)
-    for tool_dir in os.listdir(tools_dir):
-        steam_tool = os.path.join(context.STEAM_COMPAT_TOOLS, tool_dir)
-        tool = os.path.join(context.TOOLS_DIR, tool_dir)
-        if not os.path.isdir(tool):
+    for entry in os.scandir(tools_dir):
+        if not entry.is_dir():
             continue
-        if not os.path.isdir(steam_tool):
-            shutil.copytree(tool,
-                            steam_tool)
-            si = CompatToolStubInfo.load_stub_info(
-                os.path.join(tool, 'stub.info'))
-            ct = CompatTool(stub_file, si)
-            ct.write_stub(steam_tool)
+        tool_name = entry.name
+        tool = ExternalCompatTool(tool_name,
+                                  ExternalCompatTool.load_stub_info(
+                                      tool_name,
+                                      stub_tpl_path)
+                                  )
+        if not os.path.exists(tool.get_install_path()):
+            tool.install()
+
+    return True
 
 
-class CompatToolStubInfo():
+class CompatToolStub():
     """Compat tool stub info"""
     url: str
     md5sum: str
     cmd: str
+    _template: str
 
-    def __init__(self, url, md5sum, cmd):
+    def __init__(self, tpl_path: str, url: str, md5sum: str, cmd: str):
         self.url = url
         self.md5sum = md5sum
         self.cmd = cmd
+        with open(tpl_path) as tpl_file:
+            self._template = tpl_file.read()
 
-    @classmethod
-    def load_stub_info(cls, stub_path):
+    def install_stub(self, tool_path: str):
+        """Install stub file on give tool_path"""
+        replacements = {
+            '%TOOL_URL%': self.url,
+            '%TOOL_MD5SUM%': self.md5sum,
+            '%TOOL_CMD%': self.cmd
+        }
+        stub_path = os.path.join(tool_path, self.cmd)
+        with open(stub_path, 'w') as stub_file:
+            stub_file.write(replace_all(self._template, replacements))
+        os.chmod(stub_path, 0o775)
+
+
+class AbsCompatTool(ABC):
+    """Abstract class to represent compatibility tools"""
+
+    name: str
+
+    def __init__(self, name: str):
+        self.name = name
+
+    @abstractmethod
+    def install(self):
+        """Install this compatibility tool"""
+
+
+class OfficialCompatTool(AbsCompatTool):
+    """Steam official compatibility tool"""
+
+    tool_id: str
+
+    def __init__(self, name: str, tool_id: str):
+        self.tool_id = tool_id
+        super().__init__(name)
+
+    def install(self):
+        if client_running():
+            install_by_id(self.tool_id)
+        else:
+            raise Exception('Steam client not running')
+
+
+class ExternalCompatTool(AbsCompatTool):
+    """Additional compatibility tool that Steam can use"""
+
+    tool_stub: CompatToolStub
+
+    def __init__(self, name: str, tool_stub: CompatToolStub):
+        self.tool_stub = tool_stub
+        super().__init__(name)
+
+    def get_install_path(self):
+        return os.path.join(context.STEAM_COMPAT_TOOLS, self.name)
+
+    def install(self):
+        ensure_directory(context.STEAM_COMPAT_TOOLS)
+        install_path = self.get_install_path()
+        shutil.copytree(os.path.join(context.TOOLS_DIR, self.name),
+                        install_path)
+        self.tool_stub.install_stub(install_path)
+
+    @staticmethod
+    def load_stub_info(tool_name: str, tpl_path: str) -> CompatToolStub:
         """Read a stub.info file from stub_path and parse it into a
         CompatToolStubInfo object.
         """
         data = {}
-        with open(stub_path) as f:
-            for line in f.readlines():
+        stub_path = os.path.join(context.TOOLS_DIR, tool_name, 'stub.info')
+        with open(stub_path) as stub_file:
+            for line in stub_file.readlines():
                 key, value = line.rstrip("\n").split("=")
                 data[key] = value
-        return CompatToolStubInfo(data['TOOL_URL'],
-                                  data['TOOL_MD5SUM'],
-                                  data['TOOL_CMD'])
-
-
-class CompatTool():
-    """Class to manage compatibility tools"""
-
-    _template: str
-    stub: CompatToolStubInfo
-
-    def __init__(self, template_path, stub_info):
-        self._template = open(template_path, 'r').read()
-        self.stub = stub_info
-
-    def write_stub(self,
-                   tool_path):
-        replacements = {
-            '%TOOL_URL%': self.stub.url,
-            '%TOOL_MD5SUM%': self.stub.md5sum,
-            '%TOOL_CMD%': self.stub.cmd
-        }
-        stub_path = os.path.join(tool_path, self.stub.cmd)
-        with open(stub_path, 'w') as stub_file:
-            stub_file.write(replace_all(self._template, replacements))
-        os.chmod(stub_path, 0o775)
+        return CompatToolStub(tpl_path,
+                              data['TOOL_URL'],
+                              data['TOOL_MD5SUM'],
+                              data['TOOL_CMD'])

--- a/chimera_app/platforms/flathub.py
+++ b/chimera_app/platforms/flathub.py
@@ -16,8 +16,12 @@ def listdir(path):
         return []
 
 
-local = os.path.join(os.getenv('XDG_DATA_HOME', os.path.expanduser('~/.local/share')), 'chimera/banners/flathub')
-files = listdir('images/flathub') + listdir(local) + listdir('/usr/share/chimera/images/flathub/')
+local = os.path.join(os.getenv('XDG_DATA_HOME',
+                               os.path.expanduser('~/.local/share')),
+                     'chimera/banners/flathub')
+files = (listdir('images/flathub')
+         + listdir(local)
+         + listdir('/usr/share/chimera/images/flathub/'))
 whitelist = [os.path.splitext(f)[0] for f in files]
 
 
@@ -29,7 +33,7 @@ class Flathub(StorePlatform):
             flathub_url = "https://dl.flathub.org/repo/flathub.flatpakrepo"
             self.__add_repo("flathub", flathub_url)
             self.__api_url = "https://flathub.org/api/v1/apps"
-        except:
+        except Exception:
             print('Error: Failed to initialize flathub support')
 
     def is_authenticated(self):
@@ -39,10 +43,16 @@ class Flathub(StorePlatform):
         return_value = None
         try:
             # This only adds the flatpak repo if it isn't already installed
-            return_value = subprocess.call(["flatpak", "remote-add", "--user", "--if-not-exists", name, url])
+            return_value = subprocess.call(["flatpak",
+                                            "remote-add",
+                                            "--user",
+                                            "--if-not-exists",
+                                            name,
+                                            url])
         finally:
             if return_value != 0:
-                print("Error: Failed to add the {name} repo to with url {url} flatpak".format(name=name, url=url))
+                print(("Error: Failed to add the {name} repo "
+                      "with url {url} flatpak").format(name=name, url=url))
 
     def __get_application_list(self):
         applications = []
@@ -65,15 +75,23 @@ class Flathub(StorePlatform):
                         installed = True
                         version = app['version']
 
-                applications.append(dic({"content_id": flatpak_id, "summary": description, "name": name,
-                                         "installed_version": version, "available_version": available_version,
-                                         "image_url": image_url, "installed": installed, "operation": None}))
+                applications.append(dic({"content_id": flatpak_id,
+                                         "summary": description,
+                                         "name": name,
+                                         "installed_version": version,
+                                         "available_version": available_version,
+                                         "image_url": image_url,
+                                         "installed": installed,
+                                         "operation": None}))
 
         return applications
 
     def __get_installed_list(self) -> List[Dict[str, any]]:
         installed_list = []
-        for line in subprocess.check_output(["flatpak", "list", "--user", "--app"]).splitlines():
+        for line in subprocess.check_output(["flatpak",
+                                             "list",
+                                             "--user",
+                                             "--app"]).splitlines():
             if isinstance(line, bytes):
                 line = line.decode("utf-8")
             try:
@@ -123,13 +141,29 @@ class Flathub(StorePlatform):
         return [app for app in apps if not app.installed]
 
     def _install(self, content) -> subprocess:
-        return subprocess.Popen([FLATPAK_WRAPPER, "install", "--user", "-y", "flathub", content.content_id],
-                                stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        return subprocess.Popen([FLATPAK_WRAPPER,
+                                 "install",
+                                 "--user",
+                                 "-y",
+                                 "flathub",
+                                 content.content_id],
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT)
 
     def _uninstall(self, content_id) -> subprocess:
-        return subprocess.Popen([FLATPAK_WRAPPER, "uninstall", "--user", "-y", content_id],
-                                stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        return subprocess.Popen([FLATPAK_WRAPPER,
+                                 "uninstall",
+                                 "--user",
+                                 "-y",
+                                 content_id],
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT)
 
     def _update(self, content_id) -> subprocess:
-        return subprocess.Popen([FLATPAK_WRAPPER, "update", "--user", "-y", content_id],
-                                stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        return subprocess.Popen([FLATPAK_WRAPPER,
+                                 "update",
+                                 "--user",
+                                 "-y",
+                                 content_id],
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT)

--- a/chimera_app/platforms/gog.py
+++ b/chimera_app/platforms/gog.py
@@ -72,7 +72,15 @@ class GOG(StorePlatform):
             cid = str(info.id)
 
             img = 'https:{img}_product_tile_256_2x.png'.format(img=info.image)
-            content.append(dic({ "content_id": cid, "summary": "", "name": info.title, "native": info.worksOn['Linux'], "installed_version": None, "available_version": None, "image_url": img, "installed": cid in installed_ids, 'operation' : None }))
+            content.append(dic({"content_id": cid,
+                                "summary": "",
+                                "name": info.title,
+                                "native": info.worksOn['Linux'],
+                                "installed_version": None,
+                                "available_version": None,
+                                "image_url": img,
+                                "installed": cid in installed_ids,
+                                'operation': None}))
 
         return content
 
@@ -85,13 +93,28 @@ class GOG(StorePlatform):
         ensure_directory(cachedir)
 
         if not content.native:
-            cmd = ["bin/gog-install", content.content_id, os.path.join(CONTENT_DIR, 'gog', content.content_id)]
-            return subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            cmd = ["bin/gog-install",
+                   content.content_id,
+                   os.path.join(CONTENT_DIR, 'gog', content.content_id)]
+            return subprocess.Popen(cmd,
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.STDOUT)
 
-        cmd = ["wyvern", "down", "--id", content.content_id, "--install", os.path.join(CONTENT_DIR, 'gog', content.content_id)]
-        return subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=cachedir)
+        cmd = ["wyvern",
+               "down",
+               "--id",
+               content.content_id,
+               "--install",
+               os.path.join(CONTENT_DIR, 'gog', content.content_id)]
+        return subprocess.Popen(cmd,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT,
+                                cwd=cachedir)
 
     def _uninstall(self, content_id) -> subprocess:
         game_dir = os.path.join(CONTENT_DIR, 'gog', content_id)
-        return subprocess.Popen(["rm", "-rf", game_dir],
-                                stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        return subprocess.Popen(["rm",
+                                 "-rf",
+                                 game_dir],
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT)

--- a/chimera_app/platforms/gog.py
+++ b/chimera_app/platforms/gog.py
@@ -6,8 +6,8 @@ import chimera_app.context as context
 from chimera_app.utils import ensure_directory
 from chimera_app.config import CONTENT_DIR
 from chimera_app.config import BANNER_DIR
+from chimera_app.shortcuts import PlatformShortcutsFile
 from chimera_app.platforms.store_platform import StorePlatform, dic
-from chimera_app.utils import load_shortcuts
 
 
 class GOG(StorePlatform):
@@ -57,7 +57,9 @@ class GOG(StorePlatform):
     def __get_all_content(self) -> list:
         content = []
 
-        installed = load_shortcuts('gog')
+        shortcuts_file = PlatformShortcutsFile('gog')
+        shortcuts_file.load_data()
+        installed = shortcuts_file.get_shortcuts_data()
         installed_ids = [game['id'] for game in installed]
 
         text = subprocess.check_output(["wyvern", "ls", "--json"])

--- a/chimera_app/platforms/store_platform.py
+++ b/chimera_app/platforms/store_platform.py
@@ -43,17 +43,23 @@ class StorePlatform:
 
     def uninstall_content(self, content_id):
         thread = threading.Thread(target=self._update_progress,
-                                  args=(self._uninstall(content_id), content_id, 'Uninstalling'))
+                                  args=(self._uninstall(content_id),
+                                        content_id,
+                                        'Uninstalling'))
         thread.start()
 
     def install_content(self, content):
         thread = threading.Thread(target=self._update_progress,
-                                  args=(self._install(content), content.content_id, 'Installing'))
+                                  args=(self._install(content),
+                                        content.content_id,
+                                        'Installing'))
         thread.start()
 
     def update_content(self, content_id):
         thread = threading.Thread(target=self._update_progress,
-                                  args=(self._update(content_id), content_id, 'Updating'))
+                                  args=(self._update(content_id),
+                                        content_id,
+                                        'Updating'))
         thread.start()
 
     def get_shortcut(self, content):

--- a/chimera_app/server.py
+++ b/chimera_app/server.py
@@ -5,7 +5,6 @@ import socket
 import tempfile
 import json
 import html
-import yaml
 import bcrypt
 import requests
 import shutil
@@ -25,7 +24,6 @@ from chimera_app.config import AUTHENTICATOR
 from chimera_app.config import SETTINGS_HANDLER
 from chimera_app.config import STEAMGRID_HANDLER
 from chimera_app.config import FTP_SERVER
-from chimera_app.config import SHORTCUT_DIR
 from chimera_app.config import RESOURCE_DIR
 from chimera_app.config import BANNER_DIR
 from chimera_app.config import CONTENT_DIR
@@ -33,15 +31,16 @@ from chimera_app.config import UPLOADS_DIR
 from chimera_app.config import SESSION_OPTIONS
 from chimera_app.config import STREAMING_HANDLER
 from chimera_app.config import MANGOHUD_HANDLER
-from chimera_app.utils import load_shortcuts
 from chimera_app.utils import sanitize
 from chimera_app.utils import upsert_file
 from chimera_app.utils import delete_file
 from chimera_app.utils import generate_banner
+from chimera_app.utils import ensure_directory_for_file
 from chimera_app.auth_decorator import authenticate
 from chimera_app.platforms.epic_store import EpicStore
 from chimera_app.platforms.flathub import Flathub
 from chimera_app.platforms.gog import GOG
+from chimera_app.shortcuts import PlatformShortcutsFile
 
 server = SessionMiddleware(app(), SESSION_OPTIONS)
 
@@ -58,7 +57,7 @@ PLATFORM_HANDLERS = {
 def authenticate_platform(selected_platform):
     if selected_platform in PLATFORM_HANDLERS:
         if not PLATFORM_HANDLERS[selected_platform].is_authenticated():
-            redirect('/platforms/{platform}'.format(platform=selected_platform))
+            redirect(f'/platforms/{selected_platform}')
             return False
     return True
 
@@ -82,22 +81,33 @@ def platform_page(platform):
                 platformName=PLATFORMS[platform]
             )
         else:
-            return template('custom_login', platform=platform, platformName=PLATFORMS[platform])
+            return template('custom_login',
+                            platform=platform,
+                            platformName=PLATFORMS[platform])
 
-    shortcuts = sorted(load_shortcuts(platform), key=lambda s: s['name'])
+    shortcut_file = PlatformShortcutsFile(platform)
+    shortcut_file.load_data()
+    shortcuts = sorted(shortcut_file.get_shortcuts_data(),
+                       key=lambda s: s['name'])
     data = []
     for shortcut in shortcuts:
         filename = None
         banner = None
-        hidden = 'hidden' if 'hidden' in shortcut and shortcut['hidden'] else ''
+        hidden = ('hidden'
+                  if 'hidden' in shortcut and shortcut['hidden']
+                  else '')
         if 'banner' in shortcut:
             filename = os.path.basename(shortcut['banner'])
-            banner = '/banners/{platform}/{filename}'.format(platform=platform, filename=filename)
-        data.append({'hidden': hidden, 'filename': filename, 'banner': banner, 'name': shortcut['name']})
+            banner = f'/banners/{platform}/{filename}'
+        data.append({'hidden': hidden,
+                     'filename': filename,
+                     'banner': banner,
+                     'name': shortcut['name']})
 
-    return template(
-        'platform.tpl', shortcuts=data, platform=platform, platformName=PLATFORMS[platform]
-    )
+    return template('platform.tpl',
+                    shortcuts=data,
+                    platform=platform,
+                    platformName=PLATFORMS[platform])
 
 
 @route('/platforms/<platform>/authenticate', method='POST')
@@ -114,7 +124,7 @@ def platform_authenticate(platform):
 @route('/banners/<platform>/<filename>')
 @authenticate
 def banners(platform, filename):
-    base = "{banner_dir}/{platform}".format(banner_dir=BANNER_DIR, platform=platform)
+    base = f'{BANNER_DIR}/{platform}'
     return static_file(filename, root='{base}'.format(base=base))
 
 
@@ -126,13 +136,21 @@ def new(platform):
             return
 
         return template(
-            'custom', app_list=PLATFORM_HANDLERS[platform].get_available_content(), isInstalledOverview=False,
-            isNew=True, platform=platform, platformName=PLATFORMS[platform]
+            'custom',
+            app_list=PLATFORM_HANDLERS[platform].get_available_content(),
+            isInstalledOverview=False,
+            isNew=True,
+            platform=platform,
+            platformName=PLATFORMS[platform]
         )
-    return template(
-        'new.tpl', isNew=True, isEditing=False, platform=platform,
-        platformName=PLATFORMS[platform], name='', hidden=''
-    )
+    return template('new.tpl',
+                    isNew=True,
+                    isEditing=False,
+                    platform=platform,
+                    platformName=PLATFORMS[platform],
+                    name='',
+                    hidden=''
+                    )
 
 
 @route('/platforms/<platform>/edit/<name>')
@@ -152,13 +170,16 @@ def edit(platform, name):
         else:
             abort(404, 'Content not found')
 
-    shortcuts = load_shortcuts(platform)
+    shortcuts = PlatformShortcutsFile(platform)
+    shortcut = shortcuts.get_shortcut_match(name, platform)
 
-    matches = [e for e in shortcuts if e['name'] == name and e['cmd'] == platform]
-    shortcut = matches[0]
-
-    return template('new.tpl', isEditing=True, platform=platform, platformName=PLATFORMS[platform],
-                    name=name, hidden=shortcut['hidden'])
+    return template('new.tpl',
+                    isEditing=True,
+                    platform=platform,
+                    platformName=PLATFORMS[platform],
+                    name=name,
+                    hidden=shortcut['hidden']
+                    )
 
 
 @route('/images/flathub/<content_id>')
@@ -189,27 +210,28 @@ def shortcut_create():
     content = request.forms.get('content')
 
     if not name or name.strip() == '':
-        redirect('/platforms/{platform}/new'.format(platform=platform))
+        redirect(f'/platforms/{platform}/new')
         return
 
     name = name.strip()
 
-    shortcuts_file = "{shortcuts_dir}/chimera.{platform}.yaml".format(shortcuts_dir=SHORTCUT_DIR, platform=platform)
-    shortcuts = load_shortcuts(platform)
+    shortcuts = PlatformShortcutsFile(platform)
 
-    matches = [e for e in shortcuts if e['name'] == name and e['cmd'] == platform]
-    if len(matches) > 0:
+    if shortcuts.get_shortcut_match(name, platform):
         return 'Shortcut already exists'
 
     banner_path = None
     if banner:
         (banner_src_path, banner_dst_name) = tmpfiles[banner]
         del tmpfiles[banner]
-        banner_path = upsert_file(banner_src_path, BANNER_DIR, platform, name, banner_dst_name)
+        banner_path = upsert_file(banner_src_path,
+                                  BANNER_DIR,
+                                  platform,
+                                  name,
+                                  banner_dst_name)
     else:
-        banner_path = os.path.join(BANNER_DIR, platform, "{}.png".format(name))
-        if not os.path.isdir(os.path.dirname(banner_path)):
-            os.makedirs(os.path.dirname(banner_path))
+        banner_path = os.path.join(BANNER_DIR, platform, f"{name}.png")
+        ensure_directory_for_file(banner_path)
         if banner_url:
             download = requests.get(banner_url)
             with open(banner_path, "wb") as banner_file:
@@ -218,18 +240,26 @@ def shortcut_create():
             generate_banner(name, banner_path)
 
     shortcut = {
-        'name': name, 'cmd': platform, 'hidden': hidden == 'on', 'banner': banner_path, 'tags': [PLATFORMS[platform]]
+        'name': name,
+        'cmd': platform,
+        'hidden': hidden == 'on',
+        'banner': banner_path,
+        'tags': [PLATFORMS[platform]]
     }
 
     if content:
         (content_src_path, content_dst_name) = tmpfiles[content]
         del tmpfiles[content]
-        content_path = upsert_file(content_src_path, CONTENT_DIR, platform, name, content_dst_name)
+        content_path = upsert_file(content_src_path,
+                                   CONTENT_DIR,
+                                   platform,
+                                   name,
+                                   content_dst_name)
         shortcut['dir'] = '"' + os.path.dirname(content_path) + '"'
         shortcut['params'] = '"' + os.path.basename(content_path) + '"'
 
-    shortcuts.append(shortcut)
-    yaml.dump(shortcuts, open(shortcuts_file, 'w'), default_flow_style=False)
+    shortcuts.add_shortcut(shortcut)
+    shortcuts.save()
 
     redirect('/platforms/{platform}'.format(platform=platform))
 
@@ -237,28 +267,29 @@ def shortcut_create():
 @route('/shortcuts/edit', method='POST')
 @authenticate
 def shortcut_update():
-    name = sanitize(request.forms.get('original_name'))  # do not allow editing name
+    # do not allow editing name
+    name = sanitize(request.forms.get('original_name'))
     platform = sanitize(request.forms.get('platform'))
     hidden = sanitize(request.forms.get('hidden'))
     banner_url = request.forms.get('banner-url')
     banner = request.forms.get('banner')
     content = request.forms.get('content')
 
-    shortcuts_file = "{shortcuts_dir}/chimera.{platform}.yaml".format(shortcuts_dir=SHORTCUT_DIR, platform=platform)
-    shortcuts = load_shortcuts(platform)
-
-    matches = [e for e in shortcuts if e['name'] == name and e['cmd'] == platform]
-    shortcut = matches[0]
+    shortcuts = PlatformShortcutsFile(platform)
+    shortcut = shortcuts.get_shortcut_match(name, platform)
 
     banner_path = None
     if banner:
         (banner_src_path, banner_dst_name) = tmpfiles[banner]
         del tmpfiles[banner]
-        banner_path = upsert_file(banner_src_path, BANNER_DIR, platform, name, banner_dst_name)
+        banner_path = upsert_file(banner_src_path,
+                                  BANNER_DIR,
+                                  platform,
+                                  name,
+                                  banner_dst_name)
     elif banner_url:
-        banner_path = os.path.join(BANNER_DIR, platform, "{}.png".format(name))
-        if not os.path.isdir(os.path.dirname(banner_path)):
-            os.makedirs(os.path.dirname(banner_path))
+        banner_path = os.path.join(BANNER_DIR, platform, f"{name}.png")
+        ensure_directory_for_file(banner_path)
         download = requests.get(banner_url)
         with open(banner_path, "wb") as banner_file:
             banner_file.write(download.content)
@@ -271,11 +302,15 @@ def shortcut_update():
     if content:
         (content_src_path, content_dst_name) = tmpfiles[content]
         del tmpfiles[content]
-        content_path = upsert_file(content_src_path, CONTENT_DIR, platform, name, content_dst_name)
+        content_path = upsert_file(content_src_path,
+                                   CONTENT_DIR,
+                                   platform,
+                                   name,
+                                   content_dst_name)
         shortcut['dir'] = '"' + os.path.dirname(content_path) + '"'
         shortcut['params'] = '"' + os.path.basename(content_path) + '"'
 
-    yaml.dump(shortcuts, open(shortcuts_file, 'w'), default_flow_style=False)
+    shortcuts.save()
 
     redirect('/platforms/{platform}'.format(platform=platform))
 
@@ -286,17 +321,12 @@ def shortcut_delete():
     name = sanitize(request.forms.get('name'))
     platform = sanitize(request.forms.get('platform'))
 
-    shortcuts_file = "{shortcuts_dir}/chimera.{platform}.yaml".format(shortcuts_dir=SHORTCUT_DIR, platform=platform)
-    shortcuts = load_shortcuts(platform)
-
-    matches = [e for e in shortcuts if e['name'] == name and e['cmd'] == platform]
-    shortcut = matches[0]
+    shortcuts = PlatformShortcutsFile(platform)
+    shortcuts.remove_shortcut_by_name(name)
+    shortcuts.save()
 
     delete_file(CONTENT_DIR, platform, name)
     delete_file(BANNER_DIR, platform, name)
-
-    shortcuts.remove(shortcut)
-    yaml.dump(shortcuts, open(shortcuts_file, 'w'), default_flow_style=False)
 
     redirect('/platforms/{platform}'.format(platform=platform))
 
@@ -365,14 +395,11 @@ def platform_install(platform, content_id):
 
     PLATFORM_HANDLERS[platform].install_content(content)
 
-    shortcuts = load_shortcuts(platform)
-    shortcut = PLATFORM_HANDLERS[platform].get_shortcut(content)
+    shortcuts = PlatformShortcutsFile(platform)
+    shortcuts.add_shortcut(PLATFORM_HANDLERS[platform].get_shortcut(content))
+    shortcuts.save()
 
-    shortcuts.append(shortcut)
-    shortcuts_file = "{shortcuts_dir}/chimera.{platform}.yaml".format(shortcuts_dir=SHORTCUT_DIR, platform=platform)
-    yaml.dump(shortcuts, open(shortcuts_file, 'w'), default_flow_style=False)
-
-    redirect('/platforms/{platform}/edit/{content_id}'.format(platform=platform, content_id=content_id))
+    redirect(f'/platforms/{platform}/edit/{content_id}')
 
 
 @route('/<platform>/uninstall/<content_id>')
@@ -383,15 +410,11 @@ def uninstall(platform, content_id):
         abort(404, 'Content not found')
     PLATFORM_HANDLERS[platform].uninstall_content(content_id)
 
-    shortcuts = load_shortcuts(platform)
-    for shortcut in shortcuts:
-        if content.name == shortcut['name']:
-            shortcuts.remove(shortcut)
-            break
-    shortcuts_file = "{shortcuts_dir}/chimera.{platform}.yaml".format(shortcuts_dir=SHORTCUT_DIR, platform=platform)
-    yaml.dump(shortcuts, open(shortcuts_file, 'w'), default_flow_style=False)
+    shortcuts = PlatformShortcutsFile(platform)
+    shortcuts.remove_shortcut(content.name, platform)
+    shortcuts.save()
 
-    redirect('/platforms/{platform}/edit/{name}'.format(platform=platform, name=content_id))
+    redirect(f'/platforms/{platform}/edit/{content_id}')
 
 
 @route('/<platform>/update/<content_id>')
@@ -402,7 +425,7 @@ def content_update(platform, content_id):
         abort(404, 'Content not found')
     PLATFORM_HANDLERS[platform].update_content(content_id)
 
-    redirect('/platforms/{platform}/edit/{name}'.format(platform=platform, name=content_id))
+    redirect(f'/platforms/{platform}/edit/{content_id}')
 
 
 @route('/<platform>/progress/<content_id>')

--- a/chimera_app/server.py
+++ b/chimera_app/server.py
@@ -31,6 +31,8 @@ from chimera_app.config import UPLOADS_DIR
 from chimera_app.config import SESSION_OPTIONS
 from chimera_app.config import STREAMING_HANDLER
 from chimera_app.config import MANGOHUD_HANDLER
+from chimera_app.compat_tools import OFFICIAL_COMPAT_TOOLS
+from chimera_app.compat_tools import OfficialCompatTool
 from chimera_app.utils import sanitize
 from chimera_app.utils import upsert_file
 from chimera_app.utils import delete_file
@@ -396,8 +398,19 @@ def platform_install(platform, content_id):
     PLATFORM_HANDLERS[platform].install_content(content)
 
     shortcuts = PlatformShortcutsFile(platform)
-    shortcuts.add_shortcut(PLATFORM_HANDLERS[platform].get_shortcut(content))
+    shortcut = PLATFORM_HANDLERS[platform].get_shortcut(content)
+    shortcuts.add_shortcut(shortcut)
     shortcuts.save()
+
+    if ('compat_tool' in shortcut
+            and shortcut['compat_tool'] in OFFICIAL_COMPAT_TOOLS):
+        name = shortcut['compat_tool']
+        tool_id = OFFICIAL_COMPAT_TOOLS[name]
+        compat_tool = OfficialCompatTool(name, tool_id)
+        try:
+            compat_tool.install()
+        except Exception as e:
+            print(e)
 
     redirect(f'/platforms/{platform}/edit/{content_id}')
 

--- a/chimera_app/shortcuts.py
+++ b/chimera_app/shortcuts.py
@@ -1,162 +1,150 @@
 """Module to manage shortcuts in the entire chimera toolset"""
 
 import os
+from typing import List
 from datetime import date
 from zlib import crc32
 import vdf
 import yaml
 import chimera_app.context as context
-from chimera_app.utils import yearsago
+import chimera_app.utils as utils
+import chimera_app.steam_config as steam_config
 
 
 def create_all_shortcuts():
     """Convenience function to create all shortcuts with default parameters"""
-    if (not os.path.isdir(context.SHORTCUT_DIRS)):
+    if not os.path.isdir(context.SHORTCUT_DIRS):
         print(f'Shortcuts directory does not exist ({context.SHORTCUT_DIRS})')
         return
-    shortcuts = ChimeraShortcuts()
-    shortcuts.get_all_shortcuts()
-    shortcuts.write_all_shortcuts()
+
+    manager = ShortcutsManager()
+    for user_dir in context.STEAM_USER_DIRS:
+        # Should change the STEAM_USER_DIRS into USER_IDS
+        manager.add_steam_file_for_user(os.path.basename(user_dir))
+
+    for file in os.scandir(context.SHORTCUT_DIRS):
+        if file.is_file():
+            manager.add_shortcuts_file_from_path(file.path)
+
+    manager.load_shortcut_entries()
+    manager.create_shortcuts()
+    manager.create_banners()
+    manager.register_compat_data()
 
 
-class ChimeraShortcuts:
-    """This class is a collection of functions to manage shortcuts in the
-    chimera toolset.
+def get_banner_id(exe, name):
+    """Returns a full 64 bit crc to match banner file names"""
+    crc_input = ''.join([exe, name])
+    high_32 = crc32(crc_input.encode('utf-8')) | 0x80000000
+    full_64 = (high_32 << 32) | 0x02000000
+    return full_64
+
+
+def get_compat_id(exe, name):
+    """Returns the lower 32 bits of unsigned the appid. Used for compat
+    tool matching
     """
+    crc_input = ''.join([exe, name])
+    return (crc32(crc_input.encode('utf-8')) & 0xffffffff) | 0x80000000
 
-    def __init__(self):
-        self.shortcuts = None
-        self.steam_shortcuts = None
 
-    def get_all_shortcuts(self):
-        data = []
-        d = context.SHORTCUT_DIRS
-        for f in os.listdir(d):
-            file_name = os.path.join(d, f)
-            data = data + self.load_shortcuts(file_name)
-        self.shortcuts = data
+def get_shortcut_id(exe, name):
+    """Returns the lower 32 bits of signed appid. Used for matching
+    existing apps.
+    """
+    return get_compat_id(exe, name) - 2**32
 
-    def write_all_shortcuts(self):
-        if not self.shortcuts:
+
+class SteamShortcutsFile():
+    """Class to manage Steam shortcuts files for users"""
+
+    path: str
+    user_id: str
+    shortcuts_data: List[dict]
+
+    def __init__(self, user_id: str):
+        self.user_id = user_id
+        self.path = os.path.join(context.STEAM_DIR,
+                                 'userdata',
+                                 user_id,
+                                 'config/shortcuts.vdf')
+        self.shortcuts_data = None
+
+    def exists(self) -> bool:
+        """Returns True if this file exists. False otherwise"""
+        return os.path.exists(self.path)
+
+    def get_shortcuts_data(self) -> List[dict]:
+        """Returns this file's shortcut data as a list of dictionaries"""
+        if not self.shortcuts_data:
+            self.load_data()
+        return self.shortcuts_data
+
+    def load_data(self) -> None:
+        """Reads shortcut data from this file. It returns a dictionary
+        with the data. If the file does not exists, it will load an empty
+        dictionary.
+        """
+        if not self.exists():
+            self.shortcuts_data = {}
             return
 
-        compat_data = {}
-        # Get current shortcuts for each user
-        for user_dir in context.STEAM_USER_DIRS:
-            steam_shortcuts = self.get_steam_shortcuts(user_dir)
+        with open(self.path, 'rb') as vdf_file:
+            data = vdf.binary_load(vdf_file)
+            if 'shortcuts' in data:
+                self.shortcuts_data = data['shortcuts']
 
-            sdict = {}
-            n = 0
-            for entry in self.shortcuts:
-                s, c = ChimeraShortcuts.create_shortcut(entry,
-                                                        steam_shortcuts)
-                sdict[str(n)] = s
-                compat_data.update(c)
-                n += 1
-            self.write_shortcuts(user_dir, sdict)
-
-        yaml.dump(compat_data,
-                  open(context.COMPAT_DATA_FILE, 'w'),
-                  default_flow_style=False)
-
-    @staticmethod
-    def get_steam_shortcuts(user_dir):
-        ss_file = user_dir + '/config/shortcuts.vdf'
-        return ChimeraShortcuts.load_steam_shortcuts(ss_file)
-
-    @staticmethod
-    def write_shortcuts(user_dir, shortcuts):
-        ss_file = user_dir + '/config/shortcuts.vdf'
-        out = {}
-        out['shortcuts'] = shortcuts
-        file = open(ss_file, 'wb')
-        file.write(vdf.binary_dumps(out))
-        file.close()
-
-    @staticmethod
-    def get_banner_id(exe, name):
-        """Returns a full 64 bit crc to match banner file names"""
-        crc_input = ''.join([exe, name])
-        high_32 = crc32(crc_input.encode('utf-8')) | 0x80000000
-        full_64 = (high_32 << 32) | 0x02000000
-        return full_64
-
-    @staticmethod
-    def get_compat_id(exe, name):
-        """Returns the lower 32 bits of unsigned the appid. Used for compat
-        tool matching
-        """
-        crc_input = ''.join([exe, name])
-        return (crc32(crc_input.encode('utf-8')) & 0xffffffff) | 0x80000000
-
-    @staticmethod
-    def get_shortcut_id(exe, name):
-        """Returns the lower 32 bits of signed appid. Used for matching
-        existing apps.
-        """
-        return ChimeraShortcuts.get_compat_id(exe, name) - 2**32
-
-    @staticmethod
-    def load_shortcuts(yaml_file):
-        """Reads shortcut data from yaml files. Can be used with a single
-        file or a list. Returns a list of dictionaries with all read shortcut
-        definitions.
-        """
-        data = []
-        if os.path.exists(yaml_file):
-            data = yaml.load(open(yaml_file, 'r'), Loader=yaml.FullLoader)
-            if isinstance(data, dict):
-                data = [data]
-        return data
-
-    @staticmethod
-    def load_steam_shortcuts(vdf_file):
-        """Reads shortcut data from a vdf file. It returns a dictionary
-        with the data.
-        """
-        data = {}
-        if os.path.exists(vdf_file):
-            s = vdf.binary_load(open(vdf_file, 'rb'))
-            if 'shortcuts' in s:
-                data = s['shortcuts']
-        return data
-
-    @staticmethod
-    def match_app_id(sc, app_id):
+    def match_app_id(self, app_id: str, create_new: bool = False) -> dict:
         """Returns the shortcut dictionary of the given app_id.
-        If not found returns {}
+        If not found returns None.
+        If create_new = True then ir returns a new empty dictionary created
+        from current shortcuts data.
         """
-        for s in sc:
-            if 'appid' in sc[s] and sc[s]['appid'] == app_id:
-                return sc[s]
-        return {}
+        if not self.shortcuts_data:
+            self.load_data()
 
-    @staticmethod
-    def create_shortcut(entry, steam_shortcuts):
-        """Returns a new shortcut and compat_data dictionary that can be
-        written later on the shortcut.vdf file and corresponding compat_data
-        yaml file.
-        If an application exists with the same app ID in the file, tries
-        to update it.
+        data = self.shortcuts_data
+        # Match shortcut dictionary and return it
+        for short in data:
+            if 'appid' in data[short] and data[short]['appid'] == app_id:
+                return data[short]
+
+        # No match found
+        if create_new:
+            # create new entry
+            new_entry = str(len(data))
+            data[new_entry] = {}
+            return data[new_entry]
+        else:
+            return None
+
+    def save(self) -> None:
+        """Save current file with current shortcuts data"""
+        out = {}
+        out['shortcuts'] = self.shortcuts_data
+        utils.ensure_directory_for_file(self.path)
+        with open(self.path, 'wb') as ss_file:
+            ss_file.write(vdf.binary_dumps(out))
+
+    def add_shortcut(self, entry: dict):
+        """Creates a new shortcut with given dictionary. Will try tom match
+        with an existing shortcut in this file. If no existing shortcut can
+        be found, then create a new entry.
         """
         if 'name' not in entry:
-            print('shortcut missing required field "name"; skipping')
-            return
+            raise Exception('Entry missing required field "name".')
         if 'cmd' not in entry:
-            print('shortcut missing required field "cmd"; skipping')
-            return
+            raise Exception('Entry missing required field "cmd".')
 
-        shortcut_id = ChimeraShortcuts.get_shortcut_id(entry['cmd'],
-                                                       entry['name'])
-        banner_id = str(ChimeraShortcuts.get_banner_id(entry['cmd'],
-                                                       entry['name']))
-        compat_id = str(ChimeraShortcuts.get_compat_id(entry['cmd'],
-                                                       entry['name']))
+        shortcut_id = get_shortcut_id(entry['cmd'], entry['name'])
 
-        shortcut = ChimeraShortcuts.match_app_id(steam_shortcuts, shortcut_id)
+        shortcut = self.match_app_id(shortcut_id, create_new=True)
         shortcut['appid'] = shortcut_id
         shortcut['AppName'] = entry['name']
         shortcut['Exe'] = entry['cmd']
+        shortcut['AllowDesktopConfig'] = 1
+        shortcut['AllowOverlay'] = 1
+        shortcut['OpenVR'] = 0
 
         if 'dir' in entry:
             shortcut['StartDir'] = entry['dir']
@@ -172,10 +160,6 @@ class ChimeraShortcuts:
         if 'icon' in entry:
             shortcut['icon'] = entry['icon']
 
-        shortcut['AllowDesktopConfig'] = 1
-        shortcut['AllowOverlay'] = 1
-        shortcut['OpenVR'] = 0
-
         if 'tags' not in shortcut:
             shortcut['tags'] = {}
 
@@ -188,7 +172,7 @@ class ChimeraShortcuts:
         TIME_WARP_DATE = None
 
         if context.TIME_WARP:
-            TIME_WARP_DATE = yearsago(int(context.TIME_WARP)).isoformat()
+            TIME_WARP_DATE = utils.yearsago(int(context.TIME_WARP)).isoformat()
 
         if TIME_WARP_DATE:
             # handle the case where the time warp or release dates changed;
@@ -217,24 +201,169 @@ class ChimeraShortcuts:
             shortcut['tags'][str(t)] = tag
             t += 1
 
-        if 'banner' in entry:
-            _, ext = os.path.splitext(entry['banner'])
-            for user_dir in context.STEAM_USER_DIRS:
-                dst_dir = user_dir + '/config/grid/'
-                if not os.path.isdir(dst_dir):
-                    os.makedirs(dst_dir)
-                dst = dst_dir + banner_id + ext
-                if os.path.islink(dst) or os.path.isfile(dst):
-                    os.remove(dst)
-                os.symlink(entry['banner'], dst)
 
+class ShortcutsFile():
+    """Class for managing our yaml shortcuts file"""
+
+    path: str
+    shortcuts_data: List[dict]
+
+    def __init__(self, path: str):
+        self.path = path
+        self.shortcuts_data = []
+
+    def exists(self) -> bool:
+        """Returns true if this file exists. False otherwise"""
+        return os.path.exists(self.path)
+
+    def get_shortcuts_data(self) -> List[dict]:
+        """Returns this file shortcuts in a list of dictionaries"""
+        return self.shortcuts_data
+
+    def load_data(self) -> None:
+        """Load shortcuts from this file"""
+        if not self.exists():
+            self.shortcuts_data = []
+            return
+
+        with open(self.path) as yaml_file:
+            data = yaml.load(yaml_file, Loader=yaml.FullLoader)
+            if isinstance(data, dict):
+                data = [data]
+        self.shortcuts_data = data
+
+    def add_shortcut(self, shortcut: dict) -> None:
+        """Add a shortcut to the end of the shortcuts data list"""
+        if 'name' not in shortcut or 'cmd' not in shortcut:
+            raise Exception(f'Passed shortcut is not valid: {shortcut}')
+        if self.get_shortcut_match(shortcut['name'], shortcut['cmd']):
+            raise Exception(f"File {self.path} already has a shortcut with "
+                            f"name {shortcut['name']} and "
+                            f"cmd {shortcut['cmd']}")
+        self.shortcuts_data.append(shortcut)
+
+    def get_shortcut_match(self, name: str, cmd: str) -> dict:
+        """Return a shortcut dictionary that matches 'name' and 'cmd'.
+        Returns empty if not found.
+        """
+        for s in self.shortcuts_data:
+            if s['name'] == name and s['cmd'] == cmd:
+                return s
+        return {}
+
+    def remove_shortcut(self, name: str, cmd: str) -> None:
+        """Remove a shortcut that has a given 'name'"""
+        for shortcut in self.shortcuts_data:
+            if name == shortcut['name'] and cmd == shortcut['cmd']:
+                self.shortcuts_data.remove(shortcut)
+                break
+
+    def save(self) -> None:
+        """Save this file with current shortcuts data"""
+        with open(self.path, 'w') as file:
+            yaml.dump(self.get_shortcuts_data(),
+                      file,
+                      default_flow_style=False)
+
+
+class PlatformShortcutsFile(ShortcutsFile):
+    """Manage a shortcuts file created for a specific platform"""
+
+    platform: str
+
+    def __init__(self, platform: str):
+        self.platform = platform
+        path = os.path.join(context.SHORTCUT_DIRS, f'chimera.{platform}.yaml')
+        super().__init__(path)
+
+
+class ShortcutsManager():
+    """Class to manage Shortcuts files and shortcut creation"""
+
+    steam_files: List[SteamShortcutsFile]
+    shortcut_files: List[ShortcutsFile]
+    shortcut_entries: List[dict]
+
+    def __init__(self,
+                 steam_files: List[SteamShortcutsFile] = None,
+                 shortcut_files: List[ShortcutsFile] = None):
+        self.steam_files = steam_files if steam_files else []
+        self.shortcut_files = shortcut_files if shortcut_files else []
+        self.shortcut_entries = []
+
+    def get_steam_files(self) -> List[SteamShortcutsFile]:
+        """Returns the steam shortcuts files list"""
+        return self.steam_files
+
+    def get_shortcuts_files(self) -> List[ShortcutsFile]:
+        """Returns the shortcuts files list"""
+        return self.shortcut_files
+
+    def add_steam_file(self, steam_file: SteamShortcutsFile) -> None:
+        """Add a steam shortcut file to this manager"""
+        self.steam_files.append(steam_file)
+
+    def add_shortcuts_file(self, shortcuts_file: ShortcutsFile) -> None:
+        """Add a shortcut file to this manager"""
+        self.shortcut_files.append(shortcuts_file)
+
+    def add_steam_file_for_user(self, user_id: str) -> None:
+        """Add a steam shortcuts file for given user_id"""
+        self.add_steam_file(SteamShortcutsFile(user_id))
+
+    def add_shortcuts_file_from_path(self, path: str) -> None:
+        """Add a shortcuts file for given path"""
+        self.add_shortcuts_file(ShortcutsFile(path))
+
+    def load_shortcut_entries(self) -> None:
+        """Load all shortcuts files into entries"""
+        for f in self.shortcut_files:
+            f.load_data()
+            self.shortcut_entries = (self.shortcut_entries
+                                     + f.get_shortcuts_data())
+
+    def create_shortcuts(self) -> None:
+        """Create all shortcuts for current entries"""
+        if not self.shortcut_entries:
+            return
+
+        for steam_file in self.steam_files:
+            for entry in self.shortcut_entries:
+                steam_file.add_shortcut(entry)
+            steam_file.save()
+
+    def create_banners(self) -> None:
+        """Create all banner files for current entries"""
+        if not self.shortcut_entries:
+            return
+
+        # Hacky way to do banners, we should consider a refactor into a class
+        for entry in self.shortcut_entries:
+            if 'banner' in entry:
+                banner_id = get_banner_id(entry['cmd'], entry['name'])
+                _, ext = os.path.splitext(entry['banner'])
+                for user_dir in context.STEAM_USER_DIRS:
+                    dst_dir = user_dir + '/config/grid/'
+                    if not os.path.isdir(dst_dir):
+                        os.makedirs(dst_dir)
+                    dst = dst_dir + str(banner_id) + ext
+                    if os.path.islink(dst) or os.path.isfile(dst):
+                        os.remove(dst)
+                    os.symlink(entry['banner'], dst)
+
+    def register_compat_data(self) -> None:
+        """Register all compatibility tools mapping for current entries"""
         compat_data = {}
-        if 'compat_tool' in entry:
-            if compat_id not in compat_data:
-                compat_data[compat_id] = {}
-            compat_data[compat_id]['compat_tool'] = entry['compat_tool']
-            if 'compat_config' in entry:
-                (compat_data[compat_id]
-                            ['compat_config']) = entry['compat_config']
+        for entry in self.shortcut_entries:
+            compat_id = get_compat_id(entry['cmd'], entry['name'])
+            if 'compat_tool' in entry:
+                if compat_id not in compat_data:
+                    compat_data[compat_id] = {}
+                compat_data[compat_id]['compat_tool'] = entry['compat_tool']
+                if 'compat_config' in entry:
+                    (compat_data[compat_id]
+                                ['compat_config']) = entry['compat_config']
 
-        return shortcut, compat_data
+        config_file = steam_config.MainSteamConfig()
+        config_file.apply_tweaks(compat_data, priority=209)
+        config_file.save()

--- a/chimera_app/steam_config.py
+++ b/chimera_app/steam_config.py
@@ -1,75 +1,180 @@
 """Submodule to handle Steam configuration files related functions"""
 
 import os
+from abc import ABC
+from abc import abstractmethod
 import vdf
 import yaml
 import chimera_app.context as context
-from chimera_app.utils import ensure_directory_for_file
+import chimera_app.utils as utils
 
 
 def apply_all_tweaks():
-    if (not os.path.exists(context.MAIN_TWEAKS_FILE)
-            and not os.path.exists(context.LOCAL_TWEAKS_FILE)):
+    """Apply all tweaks if tweaks files exits"""
+    main_file = TweaksFile(context.MAIN_TWEAKS_FILE)
+    local_file = TweaksFile(context.LOCAL_TWEAKS_FILE)
+    if (not main_file.exists() and not local_file.exists()):
         print('No tweaks to apply')
         return
-    sc = SteamConfig()
-    sc.apply_tweaks()
+
+    main_config = MainSteamConfig()
+    if main_file.exists():
+        main_config.apply_tweaks(main_file.get_data(), priority=209)
+    if local_file.exists():
+        main_config.apply_tweaks(local_file.get_data(), priority=229)
+    main_config.save()
+
+    for user_dir in context.STEAM_USER_DIRS:
+        user_id = os.path.basename(user_dir)
+        user_config = LocalSteamConfig(user_id)
+        if main_file.exists():
+            user_config.apply_tweaks(main_file.get_data())
+        if local_file.exists():
+            user_config.apply_tweaks(local_file.get_data())
+        user_config.save()
 
 
-class SteamConfig:
-    """This class is menat to handle all steam configuration files.
-    The basic usage would be:
-        sc = SteamConfig()
-        sc.update()
-        sc.apply_tweaks()
-    """
+class TweaksFile:
+    """Manage a tweaks file"""
 
-    def apply_tweaks(self):
-        ensure_directory_for_file(context.STEAM_CONFIG_FILE)
+    path: str
+    tweaks_data: dict
 
-        config_data = self.load_main(context.STEAM_CONFIG_FILE)
+    def __init__(self, path: str):
+        self.path = path
+        self.tweaks_data = None
 
-        # add global entries if file exists
-        self.apply_to_main_config(context.MAIN_TWEAKS_FILE,
-                                  config_data,
-                                  priority=209)
-        # add local entries if file exists
-        self.apply_to_main_config(context.LOCAL_TWEAKS_FILE,
-                                  config_data,
-                                  priority=229)
-        # add shortcut compat data
-        self.apply_to_main_config(context.COMPAT_DATA_FILE,
-                                  config_data,
-                                  priority=209)
-        self.write(config_data, context.STEAM_CONFIG_FILE)
+    def exists(self) -> bool:
+        """Returns True if this tweaks file exists"""
+        return os.path.exists(self.path)
 
-        for user_dir in context.STEAM_USER_DIRS:
-            config_file = user_dir + '/config/localconfig.vdf'
+    def load_data(self) -> None:
+        """Load this file's data"""
+        with open(self.path) as file:
+            self.tweaks_data = yaml.load(file, Loader=yaml.FullLoader)
 
-            ensure_directory_for_file(config_file)
+    def get_data(self) -> dict:
+        """Return this file's data as a dictionary"""
+        if not self.tweaks_data:
+            self.load_data()
+        return self.tweaks_data
 
-            config_data = self.load_local(config_file)
 
-            # Add global entries if file exists
-            self.apply_to_local_config(context.MAIN_TWEAKS_FILE, config_data)
-            # Add local entries if file exists
-            self.apply_to_local_config(context.LOCAL_TWEAKS_FILE, config_data)
+class SteamConfigFile(ABC):
+    """Class to represent a Steam configuration file"""
 
-            self.write(config_data, config_file)
+    path: str
+    config_data: vdf.VDFDict
 
-    @staticmethod
-    def write(config_data, config_file):
-        conf = vdf.dumps(config_data, pretty=True)
-        with open(config_file, 'w') as file:
+    def __init__(self, path: str):
+        self.path = path
+        self.config_data = None
+
+    def exists(self) -> bool:
+        """Returns True if the file exists, False otherwise"""
+        return os.path.exists(self.path)
+
+    @abstractmethod
+    def apply_tweaks(self, tweak_data: dict, priority: int) -> None:
+        """Apply tweaks data to this configuration file"""
+
+    @abstractmethod
+    def load_data(self) -> None:
+        """Load data contained in this file and return a dictionary"""
+
+    def save(self) -> None:
+        """Save the file"""
+        conf = vdf.dumps(self.config_data, pretty=True)
+        utils.ensure_directory_for_file(self.path)
+        with open(self.path, 'w') as file:
             file.write(conf)
 
-    @staticmethod
-    def load_main(path):
-        if os.path.exists(path):
-            data = vdf.load(open(path))
+
+class LocalSteamConfig(SteamConfigFile):
+    """Handle local user Steam config file"""
+
+    user_id: str
+
+    def __init__(self, user_id: str):
+        self.user_id = user_id
+        path_to_file = os.path.join(context.STEAM_DIR,
+                                    'userdata',
+                                    user_id,
+                                    'config/localconfig.vdf'
+                                    )
+        super().__init__(path_to_file)
+
+    def load_data(self) -> None:
+        if self.exists():
+            data = vdf.load(open(self.path))
         else:
             data = vdf.VDFDict()
-            data['InstallConfigStore'] = {'Software': {'Valve': {'Steam': {}}}}
+            data['UserLocalConfigStore'] = {'Software':
+                                            {'Valve':
+                                             {'Steam': {}
+                                              }
+                                             }
+                                            }
+
+        steam_input = data['UserLocalConfigStore']
+        if 'Apps' not in steam_input:
+            steam_input['Apps'] = {}
+
+        launch_options = (data['UserLocalConfigStore']
+                              ['Software']
+                              ['Valve']
+                              ['Steam'])
+        if 'Apps' not in launch_options:
+            launch_options['Apps'] = {}
+
+        self.config_data = data
+
+    def apply_tweaks(self, tweak_data: dict, priority=0) -> None:
+        if not self.config_data:
+            self.load_data()
+
+        steam_input_data = self.config_data['UserLocalConfigStore']['Apps']
+        launch_options = (self.config_data['UserLocalConfigStore']
+                                          ['Software']
+                                          ['Valve']
+                                          ['Steam']
+                                          ['Apps'])
+
+        for key in tweak_data:
+            if ('steam_input' in tweak_data[key] and
+                    tweak_data[key]['steam_input'] == 'enabled'):
+                steam_input_data[key] = {
+                    "UseSteamControllerConfig": "2",
+                    "SteamControllerRumble": "-1",
+                    "SteamControllerRumbleIntensity": "320",
+                    "EnableSCTenFootOverlayCheckNew": "1"
+                }
+
+            if 'launch_options' in tweak_data[key]:
+                if key not in launch_options:
+                    launch_options[key] = {}
+                launch_options[key]['LaunchOptions'] = (tweak_data[key]
+                                                        ['launch_options'])
+
+
+class MainSteamConfig(SteamConfigFile):
+    """Handle main Steam config file"""
+
+    def __init__(self):
+        path_to_file = os.path.join(context.STEAM_DIR, 'config/config.vdf')
+        super().__init__(path_to_file)
+
+    def load_data(self) -> None:
+        if self.exists():
+            data = vdf.load(open(self.path))
+        else:
+            data = vdf.VDFDict()
+            data['InstallConfigStore'] = {'Software':
+                                          {'Valve':
+                                           {'Steam': {}
+                                            }
+                                           }
+                                          }
 
         steam = data['InstallConfigStore']['Software']['Valve']['Steam']
 
@@ -88,77 +193,22 @@ class SteamConfig:
             for entry in stale_entries:
                 del steam['CompatToolMapping'][entry]
 
-        return data
+        self.config_data = data
 
-    @staticmethod
-    def load_local(path):
-        if os.path.exists(path):
-            data = vdf.load(open(path))
-        else:
-            data = vdf.VDFDict()
-            data['UserLocalConfigStore'] = {'Software':
-                                            {'Valve':
-                                             {'Steam': {}
-                                              }
-                                             }
-                                            }
+    def apply_tweaks(self, tweak_data: dict, priority=209) -> None:
+        if not self.config_data:
+            self.load_data()
+        compat = (self.config_data['InstallConfigStore']['Software']['Valve']
+                                  ['Steam']['CompatToolMapping'])
 
-        steam_input = data['UserLocalConfigStore']
-        if 'Apps' not in steam_input:
-            steam_input['Apps'] = {}
-
-        launch_options = (data['UserLocalConfigStore']['Software']['Valve']
-                          ['Steam'])
-        if 'Apps' not in launch_options:
-            launch_options['Apps'] = {}
-
-        return data
-
-    @staticmethod
-    def apply_to_main_config(tweaks_file, steam_data, priority=209):
-        """write tweaks into Steam config data."""
-
-        if not os.path.exists(tweaks_file):
-            return
-
-        compat = (steam_data['InstallConfigStore']['Software']['Valve']
-                  ['Steam']['CompatToolMapping'])
-
-        data = yaml.load(open(tweaks_file), Loader=yaml.FullLoader)
-        for key in data:
+        for key in tweak_data:
             if (key not in compat or
                     'Priority' not in compat[key] or
                     int(compat[key]['Priority']) <= priority):
-                if 'compat_tool' in data[key]:
+                if 'compat_tool' in tweak_data[key]:
                     entry = {}
-                    entry['name'] = data[key]['compat_tool']
-                    if 'compat_config' in data[key]:
-                        entry['config'] = data[key]['compat_config']
+                    entry['name'] = tweak_data[key]['compat_tool']
+                    if 'compat_config' in tweak_data[key]:
+                        entry['config'] = tweak_data[key]['compat_config']
                     entry['Priority'] = priority
                     compat[key] = entry
-
-    @staticmethod
-    def apply_to_local_config(tweaks_file, steam_data):
-        if not os.path.exists(tweaks_file):
-            return
-
-        steam_input_data = steam_data['UserLocalConfigStore']['Apps']
-        launch_options = (steam_data['UserLocalConfigStore']['Software']
-                          ['Valve']['Steam']['Apps'])
-
-        data = yaml.load(open(tweaks_file), Loader=yaml.FullLoader)
-        for key in data:
-            if ('steam_input' in data[key] and
-                    data[key]['steam_input'] == 'enabled'):
-                steam_input_data[key] = {
-                    "UseSteamControllerConfig": "2",
-                    "SteamControllerRumble": "-1",
-                    "SteamControllerRumbleIntensity": "320",
-                    "EnableSCTenFootOverlayCheckNew": "1"
-                }
-
-            if 'launch_options' in data[key]:
-                if key not in launch_options:
-                    launch_options[key] = {}
-                launch_options[key]['LaunchOptions'] = (data[key]
-                                                        ['launch_options'])

--- a/chimera_app/utils.py
+++ b/chimera_app/utils.py
@@ -2,7 +2,9 @@
 import os
 import re
 import shutil
+import subprocess
 from datetime import datetime
+import psutil
 import yaml
 from PIL import Image, ImageFont, ImageDraw
 import chimera_app.context as context
@@ -161,3 +163,25 @@ def generate_banner(text, path):
     title.text((text_x, text_y), text, font=font, fill=(255, 255, 255))
 
     banner.save(path)
+
+
+def client_running() -> False:
+    """Check if the Steam client is running"""
+    pid_path = os.path.expanduser('~/.steam/steam.pid')
+    if not os.path.exists(pid_path):
+        return False
+    with open(pid_path) as pid_file:
+        pid = pid_file.read()
+    try:
+        maybe_steam = psutil.Process(pid)
+    except psutil.NoSuchProcess:
+        return False
+    return maybe_steam.name() == 'steam'
+
+
+def install_by_id(steam_id: str) -> None:
+    if client_running():
+        subprocess.run(['steam', 'steam://install/' + steam_id],
+                       check=True)
+    else:
+        raise Exception('Steam Client is not running')

--- a/chimera_app/utils.py
+++ b/chimera_app/utils.py
@@ -8,6 +8,7 @@ import psutil
 import yaml
 from PIL import Image, ImageFont, ImageDraw
 import chimera_app.context as context
+import chimera_app.shortcuts as shortcuts
 
 
 def ensure_directory(directory):
@@ -123,10 +124,8 @@ def strip(string):
 
 def delete_file(base_dir, platform, name):
     if is_direct(platform, os.path.basename(base_dir)):
-        shortcuts = load_shortcuts(platform)
-        matches = ([e for e in shortcuts if e['name'] == name
-                    and e['cmd'] == platform])
-        shortcut = matches[0]
+        shortcuts_file = shortcuts.PlatformShortcutsFile(platform)
+        shortcut = shortcuts_file.get_shortcut_match(name, platform)
         if 'dir' in shortcut and 'params' in shortcut:
             file_path = os.path.join(strip(shortcut['dir']),
                                      strip(shortcut['params']))

--- a/chimera_app/utils.py
+++ b/chimera_app/utils.py
@@ -5,7 +5,6 @@ import shutil
 import subprocess
 from datetime import datetime
 import psutil
-import yaml
 from PIL import Image, ImageFont, ImageDraw
 import chimera_app.context as context
 import chimera_app.shortcuts as shortcuts
@@ -43,21 +42,6 @@ def sanitize(string):
         retval.replace('"', '')
         return retval
     return string
-
-
-def load_shortcuts(platform):
-    shortcuts = []
-    ensure_directory(context.SHORTCUT_DIRS)
-
-    shortcuts_file = (context.SHORTCUT_DIRS +
-                      "/chimera.{platform}.yaml".format(platform=platform))
-    if os.path.exists(shortcuts_file):
-        shortcuts = yaml.load(open(shortcuts_file), Loader=yaml.Loader)
-
-    if not shortcuts:
-        shortcuts = []
-
-    return shortcuts
 
 
 def delete_file_link(base_dir, platform, name):

--- a/tests/test_compat_tools.py
+++ b/tests/test_compat_tools.py
@@ -1,0 +1,53 @@
+"""Test relevant compat_tools module functions"""
+
+import os
+import pytest
+from chimera_app.compat_tools import ExternalCompatTool
+
+
+@pytest.fixture
+def fake_data(fs,
+              monkeypatch):
+    files_path = os.path.join(os.path.dirname(__file__), 'files')
+
+    fs.create_dir(os.path.expanduser('~/.cache'))
+    fs.create_dir(os.path.expanduser('~/.local/share/chimera'))
+    fs.add_real_directory(os.path.join(files_path,
+                                       'tools',
+                                       'Proton-6.10-GE-1'),
+                          target_path=os.path.expanduser(
+                              ('~/.local/share/chimera/data/'
+                               'compat/tools/Proton-6.10-GE-1')
+                                                         )
+                          )
+    fs.add_real_file(os.path.join(files_path, 'tool-stub.tpl'),
+                     target_path=os.path.expanduser(
+                         ('~/.local/share/chimera/data/'
+                          'compat/tools/tool-stub.tpl')
+                                                    )
+                     )
+
+    yield fs
+
+
+def test_external_compat_tool_install(fake_data):
+    compat_tools_dir = os.path.expanduser(
+        '~/.local/share/Steam/compatibilitytools.d')
+    proton_ge_dir = os.path.join(compat_tools_dir, 'Proton-6.10-GE-1')
+    chimera_data_tools = os.path.expanduser(
+        '~/.local/share/chimera/data/compat/tools'
+    )
+    stub_tpl_path = os.path.join(chimera_data_tools, 'tool-stub.tpl')
+
+    tool = ExternalCompatTool('Proton-6.10-GE-1',
+                              ExternalCompatTool.load_stub_info(
+                                  'Proton-6.10-GE-1',
+                                  stub_tpl_path)
+                              )
+    tool.install()
+
+    assert(os.path.exists(proton_ge_dir))
+    assert(os.path.exists(os.path.join(proton_ge_dir, 'proton')))
+    assert(os.path.exists(os.path.join(proton_ge_dir, 'toolmanifest.vdf')))
+    assert(os.path.exists(os.path.join(proton_ge_dir,
+                                       'compatibilitytool.vdf')))

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -4,9 +4,9 @@ import os
 import vdf
 import pytest
 import chimera_app
-from chimera_app.shortcuts import create_all_shortcuts
-from chimera_app.steam_config import apply_all_tweaks
-from chimera_app.compat_tools import install_all_compat_tools
+import chimera_app.shortcuts as shortcuts
+import chimera_app.steam_config as steam_config
+import chimera_app.compat_tools as compat_tools
 
 
 @pytest.fixture
@@ -66,7 +66,7 @@ def test_config_with_empty(empty_data):
     user_config_file = os.path.expanduser(
         '~/.local/share/Steam/userdata/12345678/config/localconfig.vdf')
 
-    apply_all_tweaks()
+    steam_config.apply_all_tweaks()
 
     assert(not os.path.exists(config_file))
     assert(not os.path.exists(user_config_file))
@@ -77,7 +77,7 @@ def test_compat_with_empty(empty_data):
         '~/.local/share/Steam/compatibilitytools.d')
     proton_ge_dir = os.path.join(compat_tools_dir, 'Proton-6.10-GE-1')
 
-    install_all_compat_tools()
+    compat_tools.install_all_compat_tools()
 
     assert(not os.path.exists(proton_ge_dir))
 
@@ -86,7 +86,7 @@ def test_shortcuts_with_empty(empty_data):
     shortcuts_file = os.path.expanduser(
         '~/.local/share/Steam/userdata/12345678/config/shortcuts.vdf')
 
-    create_all_shortcuts()
+    shortcuts.create_all_shortcuts()
 
     assert(not os.path.exists(shortcuts_file))
 
@@ -99,7 +99,7 @@ def test_config_with_data(fake_data):
     user_config_file = os.path.expanduser(
         '~/.local/share/Steam/userdata/12345678/config/localconfig.vdf')
 
-    apply_all_tweaks()
+    steam_config.apply_all_tweaks()
 
     assert(os.path.exists(config_file))
     conf_vdf = vdf.load(open(config_file))
@@ -129,7 +129,7 @@ def test_compat_with_data(fake_data):
         '~/.local/share/Steam/compatibilitytools.d')
     proton_ge_dir = os.path.join(compat_tools_dir, 'Proton-6.10-GE-1')
 
-    install_all_compat_tools()
+    compat_tools.install_all_compat_tools()
 
     assert(os.path.exists(proton_ge_dir))
     assert(os.path.exists(os.path.join(proton_ge_dir, 'proton')))
@@ -142,7 +142,7 @@ def test_shortcuts_with_data(fake_data):
     shortcuts_file = os.path.expanduser(
         '~/.local/share/Steam/userdata/12345678/config/shortcuts.vdf')
 
-    create_all_shortcuts()
+    shortcuts.create_all_shortcuts()
 
     assert(os.path.exists(shortcuts_file))
     sh_data = vdf.binary_load(open(shortcuts_file, 'rb'))

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -79,6 +79,7 @@ def test_compat_with_empty(empty_data):
 
     compat_tools.install_all_compat_tools()
 
+    assert(not os.path.exists(compat_tools_dir))
     assert(not os.path.exists(proton_ge_dir))
 
 

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -1,54 +1,89 @@
 """Unit tests for relevant shortcuts module functions"""
 
 import os
-import tempfile
-from chimera_app.shortcuts import ChimeraShortcuts as CShort
+import pytest
+import chimera_app.context as context
+import chimera_app.shortcuts as shortcuts
+from chimera_app.shortcuts import ShortcutsFile
+from chimera_app.shortcuts import SteamShortcutsFile
 
 
-def test_static_load_shortcuts():
-    yaml_content = '\n'.join(
-        ['- name: Firefox',
-         '  cmd: firefox',
-         '- name: Chromium',
-         '  cmd: chromium']
-    )
-    tmp_file = tempfile.NamedTemporaryFile(delete=False)
-    tmp_file.write(yaml_content.encode())
-    tmp_file.close()
-
-    # Read the file
-    s = CShort.load_shortcuts(tmp_file.name)
-    try:
-        assert(s[0]['name'] == 'Firefox')
-        assert(s[0]['cmd'] == 'firefox')
-        assert(s[1]['name'] == 'Chromium')
-        assert(s[1]['cmd'] == 'chromium')
-    finally:
-        tmp_file.close()
-        os.unlink(tmp_file.name)
+@pytest.fixture
+def empty_data(fs):
+    fs.create_dir(os.path.expanduser('~'))
+    yield fs
 
 
-def test_static_load_steam_shortcuts():
-    yaml_content = '\n'.join(
-        ['- name: Firefox',
-         '  cmd: firefox',
-         '- name: Chromium',
-         '  cmd: chromium']
-    )
-    tmp_file = tempfile.NamedTemporaryFile(delete=False)
-    tmp_file.write(yaml_content.encode())
-    tmp_file.close()
+@pytest.fixture
+def fake_data(fs,
+              monkeypatch):
+    files_path = os.path.join(os.path.dirname(__file__), 'files')
 
-    # Read the file
-    s = CShort.load_shortcuts(tmp_file.name)
-    try:
-        assert(s[0]['name'] == 'Firefox')
-        assert(s[0]['cmd'] == 'firefox')
-        assert(s[1]['name'] == 'Chromium')
-        assert(s[1]['cmd'] == 'chromium')
-    finally:
-        tmp_file.close()
-        os.unlink(tmp_file.name)
+    fs.create_dir(os.path.expanduser('~/.cache'))
+    fs.create_dir(os.path.expanduser('~/.local/share/chimera'))
+    fs.create_dir(os.path.expanduser('~/.local/share/Steam/config'))
+    fs.create_dir(os.path.expanduser(
+        '~/.local/share/Steam/userdata/12345678'))
+    fs.add_real_file(os.path.join(files_path, 'steam-tweaks.yaml'),
+                     target_path=os.path.expanduser(
+                         '~/.local/share/chimera/data/tweaks/steam.yaml')
+                     )
+    fs.add_real_file(os.path.join(files_path, 'test-shortcuts-single.yaml'),
+                     target_path=os.path.expanduser(
+                         '~/.local/share/chimera/shortcuts/single.yaml')
+                     )
+    fs.add_real_file(os.path.join(files_path, 'test-shortcuts-multi.yaml'),
+                     target_path=os.path.expanduser(
+                         '~/.local/share/chimera/shortcuts/multi.yaml')
+                     )
+
+    # Patch STEAM_USER_DIRS as per pyfakefs limitations
+    monkeypatch.setattr(context, 'STEAM_USER_DIRS',
+                        [os.path.expanduser(
+                            '~/.local/share/Steam/userdata/12345678')]
+                        )
+    yield fs
+
+
+def test_steam_shortcuts_load_empty(empty_data):
+    steam_short = SteamShortcutsFile('12345678')
+
+    assert(not steam_short.exists())
+
+    steam_short.load_data()
+
+    assert(steam_short.get_shortcuts_data() == {})
+
+
+def test_shortcuts_load_data_single(fake_data):
+    shortcut_path = os.path.expanduser(
+        '~/.local/share/chimera/shortcuts/single.yaml')
+
+    file = ShortcutsFile(shortcut_path)
+    file.load_data()
+
+    assert(file.shortcuts_data[0]['name'] == 'Firefox')
+    assert(file.shortcuts_data[0]['cmd'] == 'firefox')
+    assert(file.shortcuts_data[0]['dir'] == '~')
+    assert(file.shortcuts_data[0]['tags'] == ['Native'])
+
+
+def test_shortcuts_load_data_multi(fake_data):
+    shortcut_path = os.path.expanduser(
+        '~/.local/share/chimera/shortcuts/multi.yaml')
+
+    file = ShortcutsFile(shortcut_path)
+    file.load_data()
+
+    assert(file.shortcuts_data[0]['name'] == 'SuperTux Native')
+    assert(file.shortcuts_data[0]['cmd'] == 'supertux2')
+    assert(file.shortcuts_data[0]['dir'] == '~')
+    assert(file.shortcuts_data[0]['tags'] == ['Native'])
+
+    assert(file.shortcuts_data[1]['name'] == 'SuperTux')
+    assert(file.shortcuts_data[1]['cmd'] == 'flatpak run')
+    assert(file.shortcuts_data[1]['dir'] == '~')
+    assert(file.shortcuts_data[1]['tags'] == ['Flathub'])
 
 
 def test_static_get_banner_id():
@@ -56,20 +91,20 @@ def test_static_get_banner_id():
     name = "SuperTuxKart"
 
     # banner id: 10898728827895152640
-    assert(CShort.get_banner_id(exe, name) == 10898728827895152640)
+    assert(shortcuts.get_banner_id(exe, name) == 10898728827895152640)
 
 
 def test_static_get_compat_id():
     exe = "$(gog-launcher 1207659723)"
     name = "Flight of the Amazon Queen"
 
-    # banner id: 10898728827895152640
-    assert(CShort.get_compat_id(exe, name) == 2967756109)
+    # compat id: 2967756109
+    assert(shortcuts.get_compat_id(exe, name) == 2967756109)
 
 
 def test_static_get_shortcut_id():
     exe = "flatpak run"
     name = "SuperTuxKart"
 
-    # banner id: 10898728827895152640
-    assert(CShort.get_shortcut_id(exe, name) == -1757409248)
+    # shortcut id: -1757409248
+    assert(shortcuts.get_shortcut_id(exe, name) == -1757409248)

--- a/tests/test_steam_config.py
+++ b/tests/test_steam_config.py
@@ -1,197 +1,134 @@
 """Unit tests for steam_config module relevant functions"""
 
 import os
-import tempfile
 import pytest
 import vdf
-from chimera_app.steam_config import SteamConfig as SC
+import chimera_app.context as context
+from chimera_app.steam_config import MainSteamConfig
+from chimera_app.steam_config import LocalSteamConfig
+from chimera_app.steam_config import TweaksFile
 
 
 @pytest.fixture
-def main_config_content():
-    """Returns a VDF content of an example steam config.vdf file"""
-    data = {
-        'InstallConfigStore': {
-            'Software': {
-                'Valve': {
-                    'Steam': {
-                        'CompatToolMapping': {
-                            '654321': {
-                                'name': 'proton_411',
-                                'config': 'noesync,nofsync',
-                                'Priority': '209'
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-    return vdf.VDFDict(data)
+def empty_data(fs):
+    fs.create_dir(os.path.expanduser('~'))
+    yield fs
 
 
 @pytest.fixture
-def local_config_content():
-    """Returns a VDF content of an example steam config.vdf file"""
-    data = {
-        'UserLocalConfigStore': {
-            'Software': {
-                'Valve': {
-                    'Steam': {
-                        'Apps': {
-                            '654321': {
-                                'LaunchOptions': '--option'
-                            }
-                        }
-                    }
-                }
-            },
-            'Apps': {
-                '654321': {
-                    'UseSteamControllerConfig': '1',
-                    'SteamControllerRumble': '-1',
-                    'SteamControllerRumbleIntensity': '320',
-                    'EnableSCTenFootOverlayCheckNew': '1'
-                }
-            }
-        }
-    }
-    return vdf.VDFDict(data)
+def fake_data(fs,
+              monkeypatch):
+    files_path = os.path.join(os.path.dirname(__file__), 'files')
+
+    fs.create_dir(os.path.expanduser('~/.cache'))
+    fs.create_dir(os.path.expanduser('~/.local/share/chimera'))
+    fs.create_dir(os.path.expanduser('~/.local/share/Steam/config'))
+    fs.create_dir(os.path.expanduser(
+        '~/.local/share/Steam/userdata/12345678'))
+    fs.add_real_file(os.path.join(files_path, 'steam-tweaks.yaml'),
+                     target_path=os.path.expanduser(
+                         '~/.local/share/chimera/data/tweaks/steam.yaml')
+                     )
+
+    # Patch STEAM_USER_DIRS as per pyfakefs limitations
+    monkeypatch.setattr(context, 'STEAM_USER_DIRS',
+                        [os.path.expanduser(
+                            '~/.local/share/Steam/userdata/12345678')]
+                        )
+    yield fs
 
 
-@pytest.fixture
-def main_config_file(main_config_content):
-    tmp_file_static = tempfile.NamedTemporaryFile(delete=False)
-    vdf.dump(main_config_content,
-             open(tmp_file_static.name, 'w'),
-             pretty=True)
-    tmp_file_static.close()
-    yield tmp_file_static
-    tmp_file_static.close()
-    os.unlink(tmp_file_static.name)
+def test_main_config_file_empty(empty_data):
+    main_config = MainSteamConfig()
+
+    assert(not main_config.exists())
+
+    main_config.load_data()
+    main_config.save()
+
+    assert(main_config.exists())
+
+    with open(context.STEAM_CONFIG_FILE) as config_file:
+        config_data = vdf.load(config_file)
+
+    assert('CompatToolMapping' in config_data['InstallConfigStore']
+                                             ['Software']
+                                             ['Valve']
+                                             ['Steam'])
 
 
-@pytest.fixture
-def local_config_file(local_config_content):
-    tmp_file_static = tempfile.NamedTemporaryFile(delete=False)
-    vdf.dump(local_config_content,
-             open(tmp_file_static.name, 'w'),
-             pretty=True)
-    tmp_file_static.close()
-    yield tmp_file_static
-    tmp_file_static.close()
-    os.unlink(tmp_file_static.name)
+def test_local_config_file_empty(empty_data):
+    local_config = LocalSteamConfig('12345678')
+
+    assert(not local_config.exists())
+
+    local_config.load_data()
+    local_config.save()
+
+    assert(local_config.exists())
+
+    with open(local_config.path) as config_file:
+        config_data = vdf.load(config_file)
+
+    assert('Apps' in config_data['UserLocalConfigStore'])
+    assert('Apps' in config_data['UserLocalConfigStore']
+                                ['Software']
+                                ['Valve']
+                                ['Steam'])
 
 
-@pytest.fixture
-def local_config_file_empty():
-    """This fixture will yield a temporary file to use as local config file"""
-    tmp_file = tempfile.NamedTemporaryFile(delete=False)
-    yield tmp_file
-    tmp_file.close()
-    os.unlink(tmp_file.name)
+def test_main_config_file_data(fake_data):
+    main_config = MainSteamConfig()
+    main_tweaks = TweaksFile(context.MAIN_TWEAKS_FILE)
+
+    assert(main_tweaks.exists())
+    assert(not main_config.exists())
+
+    main_config.apply_tweaks(main_tweaks.get_data(), priority=209)
+    main_config.save()
+
+    assert(main_config.exists())
+
+    with open(context.STEAM_CONFIG_FILE) as config_file:
+        config_data = vdf.load(config_file)
+
+    tool_mapping = (config_data['InstallConfigStore']
+                               ['Software']
+                               ['Valve']
+                               ['Steam']
+                               ['CompatToolMapping'])
+    assert(tool_mapping['221380']['name'] == 'proton_411')
+    assert(tool_mapping['221380']['Priority'] == '209')
+    assert(tool_mapping['409710']['name'] == 'proton_513')
+    assert(tool_mapping['409710']['Priority'] == '209')
 
 
-@pytest.fixture
-def main_config_file_empty():
-    """This fixture will yield a temporary file to use as main config file"""
-    tmp_file = tempfile.NamedTemporaryFile(delete=False)
-    yield tmp_file
-    tmp_file.close()
-    os.unlink(tmp_file.name)
+def test_local_config_file_data(fake_data):
+    local_config = LocalSteamConfig('12345678')
+    main_tweaks = TweaksFile(context.MAIN_TWEAKS_FILE)
 
+    assert(main_tweaks.exists())
+    assert(not local_config.exists())
 
-@pytest.fixture
-def tweaks_content():
-    """This will return a test content for a tweaks file"""
-    yaml_content = '\n'.join(
-        ['"12345678":',
-         '  compat_tool: compat_tool',
-         '',
-         '"321040":',
-         '  compat_tool: proton_411',
-         '  compat_config: noesync',
-         '  launch_options: MY_VARIABLE=1 %command%',
-         '  steam_input: enabled']
-    )
-    return yaml_content
+    local_config.apply_tweaks(main_tweaks.get_data())
+    local_config.save()
 
+    assert(local_config.exists())
 
-@pytest.fixture
-def tweaks_file_empty():
-    """This fixture will yield a temporary file to use as user tweaks file"""
-    tmp_file = tempfile.NamedTemporaryFile(delete=False)
-    yield tmp_file
-    tmp_file.close()
-    os.unlink(tmp_file.name)
+    with open(local_config.path) as config_file:
+        config_data = vdf.load(config_file)
 
+    launch_options = (config_data['UserLocalConfigStore']
+                                 ['Software']
+                                 ['Valve']
+                                 ['Steam']
+                                 ['Apps'])
+    steam_input = config_data['UserLocalConfigStore']['Apps']
 
-@pytest.fixture
-def tweaks_file(tweaks_content):
-    """This fixture will yield a tweaks file as it where downloaded from the
-    repository
-    """
-    tmp_file_static = tempfile.NamedTemporaryFile(delete=False)
-    open(tmp_file_static.name, 'wb').write(tweaks_content.encode())
-    tmp_file_static.close()
-    yield tmp_file_static
-    tmp_file_static.close()
-    os.unlink(tmp_file_static.name)
-
-
-def test_load_main(main_config_file,
-                   main_config_content):
-    config = SC.load_main(main_config_file.name)
-    assert(vdf.load(open(main_config_file.name)) == config)
-
-
-def test_load_local(local_config_file,
-                    local_config_content):
-    config = SC.load_local(local_config_file.name)
-    assert(vdf.load(open(local_config_file.name)) == config)
-
-
-def test_write(local_config_content,
-               main_config_content,
-               local_config_file_empty,
-               main_config_file_empty):
-    SC.write(local_config_content,
-             local_config_file_empty.name)
-    SC.write(main_config_content,
-             main_config_file_empty.name)
-
-    mf_content = vdf.load(open(main_config_file_empty.name))
-    assert(mf_content['InstallConfigStore'] ==
-           main_config_content['InstallConfigStore'])
-    steam_file = (mf_content['InstallConfigStore']['Software']['Valve']
-                  ['Steam'])
-    steam_data = (main_config_content['InstallConfigStore']['Software']
-                  ['Valve']['Steam'])
-    assert(steam_file['CompatToolMapping'] == steam_data['CompatToolMapping'])
-
-    lf_content = vdf.load(open(local_config_file_empty.name))
-    assert(lf_content['UserLocalConfigStore'] ==
-           local_config_content['UserLocalConfigStore'])
-
-
-def test_apply_to_main_config(tweaks_file,
-                              main_config_content):
-    SC.apply_to_main_config(tweaks_file.name,
-                            main_config_content,
-                            priority=209
-                            )
-
-    compat = (main_config_content['InstallConfigStore']['Software']['Valve']
-              ['Steam']['CompatToolMapping'])
-    assert(compat['12345678']['name'] == 'compat_tool')
-    assert(compat['12345678']['Priority'] == 209)
-
-
-def test_apply_to_local_config(tweaks_file,
-                               local_config_content):
-    SC.apply_to_local_config(tweaks_file.name, local_config_content)
-
-    launch_options = (local_config_content['UserLocalConfigStore']['Software']
-                      ['Valve']['Steam']['Apps'])
-    assert(launch_options['321040']['LaunchOptions'] ==
-           'MY_VARIABLE=1 %command%')
+    assert(launch_options['285820']['LaunchOptions'] ==
+           'LD_LIBRARY_PATH= %command%')
+    assert(launch_options['331870']['LaunchOptions'] ==
+           '%command% -screen-fullscreen 0')
+    assert(launch_options['409710']['LaunchOptions'] ==
+           '-nointro')
+    assert(steam_input['285820']['UseSteamControllerConfig'] == '2')


### PR DESCRIPTION
Various changes needed to improve code quality and integration between tools that lead to the implementation of install proton versions:
- Refactor `shortcuts`, `compat_tools` and `steam_confg` for better integration in the future:
  - This removes the need of a compatibility tool file under `.cache`
  - Shortcuts are handled by their own classes and a manager for bulk operations.
- Improve Linting on platform handlers
- Implement install of official proton versions if an installed game from another platform needs it.