### PR TITLE
Improve url quotation

### DIFF
--- a/views/custom.tpl
+++ b/views/custom.tpl
@@ -8,10 +8,11 @@
 </div>
 % end
 
+% from urllib.parse import quote
 % for app in app_list:
 <div class="img-container">
     <a href="/library/{{ platform }}/edit/{{ app.content_id }}">
-        <img src="{{ app.image_url }}" alt="{{ app.name }}" title="{{ app.name }}"></img>
+        <img src="{{ quote(app.image_url) }}" alt="{{ app.name }}" title="{{ app.name }}"></img>
     </a>
 </div>
 % end

--- a/views/platform.tpl
+++ b/views/platform.tpl
@@ -6,13 +6,14 @@
     </a>
 </div>
 
+% from urllib.parse import quote
 % for s in shortcuts:
-<a href="/library/{{platform}}/edit/{{s['name']}}">
+<a href="/library/{{platform}}/edit/{{quote(s['name'])}}">
     <div class="img-container {{s['hidden']}}">
         % if s['banner'] == None :
             <span class="missing-text">{{s['name']}}</span>
         % else :
-            <img class="{{s['hidden']}}" src="{{s['banner']}}" alt="{{s['name']}}" title="{{s['name']}}"/>
+            <img class="{{s['hidden']}}" src="{{quote(s['banner'])}}" alt="{{s['name']}}" title="{{s['name']}}"/>
         % end
     </div>
 </a>


### PR DESCRIPTION
bottle does not quote urls by default. This makes for a difficulty in names used as URLs when they contain accents and spaces. 