### PR TITLE
Add auto_load optional argument

### DIFF
--- a/chimera_app/platforms/gog.py
+++ b/chimera_app/platforms/gog.py
@@ -58,7 +58,6 @@ class GOG(StorePlatform):
         content = []
 
         shortcuts_file = PlatformShortcutsFile('gog')
-        shortcuts_file.load_data()
         installed = shortcuts_file.get_shortcuts_data()
         installed_ids = [game['id'] for game in installed]
 

--- a/chimera_app/server.py
+++ b/chimera_app/server.py
@@ -99,7 +99,6 @@ def platform_page(platform):
                             platformName=PLATFORMS[platform])
 
     shortcut_file = PlatformShortcutsFile(platform)
-    shortcut_file.load_data()
     shortcuts = sorted(shortcut_file.get_shortcuts_data(),
                        key=lambda s: s['name'])
     data = []
@@ -184,7 +183,6 @@ def edit(platform, name):
             abort(404, 'Content not found')
 
     shortcuts = PlatformShortcutsFile(platform)
-    shortcuts.load_data()
     shortcut = shortcuts.get_shortcut_match(name, platform)
 
     return template('new.tpl',
@@ -230,7 +228,6 @@ def shortcut_create():
     name = name.strip()
 
     shortcuts = PlatformShortcutsFile(platform)
-    shortcuts.load_data()
 
     if shortcuts.get_shortcut_match(name, platform):
         return 'Shortcut already exists'
@@ -291,7 +288,6 @@ def shortcut_update():
     content = request.forms.get('content')
 
     shortcuts = PlatformShortcutsFile(platform)
-    shortcuts.load_data()
     shortcut = shortcuts.get_shortcut_match(name, platform)
 
     banner_path = None
@@ -338,7 +334,6 @@ def shortcut_delete():
     platform = sanitize(request.forms.get('platform'))
 
     shortcuts = PlatformShortcutsFile(platform)
-    shortcuts.load_data()
     shortcuts.remove_shortcut(name, platform)
     shortcuts.save()
 
@@ -413,7 +408,6 @@ def platform_install(platform, content_id):
     PLATFORM_HANDLERS[platform].install_content(content)
 
     shortcuts = PlatformShortcutsFile(platform)
-    shortcuts.load_data()
     shortcut = PLATFORM_HANDLERS[platform].get_shortcut(content)
     shortcuts.add_shortcut(shortcut)
     shortcuts.save()
@@ -440,7 +434,6 @@ def uninstall(platform, content_id):
     PLATFORM_HANDLERS[platform].uninstall_content(content_id)
 
     shortcuts = PlatformShortcutsFile(platform)
-    shortcuts.load_data()
     shortcuts.remove_shortcut(content.name, platform)
     shortcuts.save()
 

--- a/chimera_app/shortcuts.py
+++ b/chimera_app/shortcuts.py
@@ -62,13 +62,15 @@ class SteamShortcutsFile():
     user_id: str
     shortcuts_data: List[dict]
 
-    def __init__(self, user_id: str):
+    def __init__(self, user_id: str, auto_load: bool = True):
         self.user_id = user_id
         self.path = os.path.join(context.STEAM_DIR,
                                  'userdata',
                                  user_id,
                                  'config/shortcuts.vdf')
         self.shortcuts_data = None
+        if auto_load:
+            self.load_data()
 
     def exists(self) -> bool:
         """Returns True if this file exists. False otherwise"""
@@ -76,8 +78,6 @@ class SteamShortcutsFile():
 
     def get_shortcuts_data(self) -> List[dict]:
         """Returns this file's shortcut data as a list of dictionaries"""
-        if not self.shortcuts_data:
-            self.load_data()
         return self.shortcuts_data
 
     def load_data(self) -> None:
@@ -208,9 +208,11 @@ class ShortcutsFile():
     path: str
     shortcuts_data: List[dict]
 
-    def __init__(self, path: str):
+    def __init__(self, path: str, auto_load: bool = True):
         self.path = path
         self.shortcuts_data = []
+        if auto_load:
+            self.load_data()
 
     def exists(self) -> bool:
         """Returns true if this file exists. False otherwise"""
@@ -272,10 +274,10 @@ class PlatformShortcutsFile(ShortcutsFile):
 
     platform: str
 
-    def __init__(self, platform: str):
+    def __init__(self, platform: str, auto_load: bool = True):
         self.platform = platform
         path = os.path.join(context.SHORTCUT_DIRS, f'chimera.{platform}.yaml')
-        super().__init__(path)
+        super().__init__(path, auto_load)
 
 
 class ShortcutsManager():

--- a/chimera_app/utils.py
+++ b/chimera_app/utils.py
@@ -109,7 +109,6 @@ def strip(string):
 def delete_file(base_dir, platform, name):
     if is_direct(platform, os.path.basename(base_dir)):
         shortcuts_file = shortcuts.PlatformShortcutsFile(platform)
-        shortcuts_file.load_data()
         shortcut = shortcuts_file.get_shortcut_match(name, platform)
         if 'dir' in shortcut and 'params' in shortcut:
             file_path = os.path.join(strip(shortcut['dir']),


### PR DESCRIPTION
Remove the need to call load_data() on shortcut file object creation. When we are sure the behaviour is expected this should be safe to keep at default.