### PR TITLE
Fix runaway img closing tag

### DIFF
--- a/views/custom.tpl
+++ b/views/custom.tpl
@@ -3,7 +3,7 @@
 % if isInstalledOverview:
 <div class="img-container">
     <a href="/library/{{ platform }}/new">
-        <img src="/images/add.png" alt="Add new shortcut" title="Add new shortcut"></img>
+        <img src="/images/add.png" alt="Add new shortcut" title="Add new shortcut"/>
     </a>
 </div>
 % end


### PR DESCRIPTION
Only happens if GOG is logged in and the page is shown. Tests will not catch it if the user is not logged in to GOG.