### PR TITLE
Various fixes for empty files handling

### DIFF
--- a/chimera_app/shortcuts.py
+++ b/chimera_app/shortcuts.py
@@ -78,7 +78,6 @@ def get_image_id(type, exe, name):
         return get_logo_id(exe, name)
 
 
-
 class SteamShortcutsFile():
     """Class to manage Steam shortcuts files for users"""
 
@@ -361,7 +360,6 @@ class ShortcutsManager():
                 steam_file.add_shortcut(entry)
             steam_file.save()
 
-
     def create_image(self, type, entry) -> None:
         if not type in entry:
             return
@@ -377,7 +375,6 @@ class ShortcutsManager():
                 os.remove(dst)
             os.symlink(entry[type], dst)
 
-
     def create_images(self) -> None:
         """Create all image files for current entries"""
         if not self.shortcut_entries:
@@ -388,7 +385,6 @@ class ShortcutsManager():
             self.create_image('poster', entry)
             self.create_image('background', entry)
             self.create_image('logo', entry)
-
 
     def register_compat_data(self) -> None:
         """Register all compatibility tools mapping for current entries"""
@@ -403,6 +399,6 @@ class ShortcutsManager():
                     (compat_data[compat_id]
                                 ['compat_config']) = entry['compat_config']
 
-        config_file = steam_config.MainSteamConfig()
+        config_file = steam_config.MainSteamConfig(auto_load=True)
         config_file.apply_tweaks(compat_data, priority=209)
         config_file.save()

--- a/chimera_app/steam_config.py
+++ b/chimera_app/steam_config.py
@@ -50,6 +50,8 @@ class TweaksFile:
 
     def load_data(self) -> None:
         """Load this file's data"""
+        if not self.exists():
+            return
         with open(self.path) as file:
             self.tweaks_data = yaml.load(file, Loader=yaml.FullLoader)
 

--- a/chimera_app/steam_config.py
+++ b/chimera_app/steam_config.py
@@ -17,7 +17,7 @@ def apply_all_tweaks():
         print('No tweaks to apply')
         return
 
-    main_config = MainSteamConfig()
+    main_config = MainSteamConfig(auto_load=True)
     if main_file.exists():
         main_config.apply_tweaks(main_file.get_data(), priority=209)
     if local_file.exists():
@@ -40,9 +40,11 @@ class TweaksFile:
     path: str
     tweaks_data: dict
 
-    def __init__(self, path: str):
+    def __init__(self, path: str, auto_load=False):
         self.path = path
         self.tweaks_data = None
+        if auto_load:
+            self.load_data()
 
     def exists(self) -> bool:
         """Returns True if this tweaks file exists"""
@@ -68,9 +70,11 @@ class SteamConfigFile(ABC):
     path: str
     config_data: vdf.VDFDict
 
-    def __init__(self, path: str):
+    def __init__(self, path: str, auto_load=False):
         self.path = path
         self.config_data = None
+        if auto_load:
+            self.load_data()
 
     def exists(self) -> bool:
         """Returns True if the file exists, False otherwise"""
@@ -97,14 +101,14 @@ class LocalSteamConfig(SteamConfigFile):
 
     user_id: str
 
-    def __init__(self, user_id: str):
+    def __init__(self, user_id: str, auto_load=False):
         self.user_id = user_id
         path_to_file = os.path.join(context.STEAM_DIR,
                                     'userdata',
                                     user_id,
                                     'config/localconfig.vdf'
                                     )
-        super().__init__(path_to_file)
+        super().__init__(path_to_file, auto_load)
 
     def load_data(self) -> None:
         if self.exists():
@@ -165,9 +169,9 @@ class LocalSteamConfig(SteamConfigFile):
 class MainSteamConfig(SteamConfigFile):
     """Handle main Steam config file"""
 
-    def __init__(self):
+    def __init__(self, auto_load=False):
         path_to_file = os.path.join(context.STEAM_DIR, 'config/config.vdf')
-        super().__init__(path_to_file)
+        super().__init__(path_to_file, auto_load)
 
     def load_data(self) -> None:
         if self.exists():

--- a/chimera_app/steam_config.py
+++ b/chimera_app/steam_config.py
@@ -130,6 +130,9 @@ class LocalSteamConfig(SteamConfigFile):
         self.config_data = data
 
     def apply_tweaks(self, tweak_data: dict, priority=0) -> None:
+        if not tweak_data:
+            print('empty tweak data, nothing to do')
+            return
         if not self.config_data:
             self.load_data()
 
@@ -196,6 +199,9 @@ class MainSteamConfig(SteamConfigFile):
         self.config_data = data
 
     def apply_tweaks(self, tweak_data: dict, priority=209) -> None:
+        if not tweak_data:
+            print('empty tweak data, nothing to do')
+            return
         if not self.config_data:
             self.load_data()
         compat = (self.config_data['InstallConfigStore']['Software']['Valve']

--- a/chimera_app/steam_config.py
+++ b/chimera_app/steam_config.py
@@ -137,7 +137,6 @@ class LocalSteamConfig(SteamConfigFile):
 
     def apply_tweaks(self, tweak_data: dict, priority=0) -> None:
         if not tweak_data:
-            print('empty tweak data, nothing to do')
             return
         if not self.config_data:
             self.load_data()
@@ -206,7 +205,6 @@ class MainSteamConfig(SteamConfigFile):
 
     def apply_tweaks(self, tweak_data: dict, priority=209) -> None:
         if not tweak_data:
-            print('empty tweak data, nothing to do')
             return
         if not self.config_data:
             self.load_data()


### PR DESCRIPTION
If there is an empty file with the same name, the tweaks script will crash chimera. This prevents that.