### PR TITLE
Removable Media Support

### DIFF
--- a/99-media-mount.rules
+++ b/99-media-mount.rules
@@ -1,0 +1,8 @@
+# Originally from https://serverfault.com/a/767079
+# Modified from SteamOS 3 99-sdcard-mount.rules
+# Run a mount script through systemd on any removable media activity
+
+KERNEL=="mmcblk0p[0-9]]", ACTION=="add", RUN+="/bin/systemctl start media-mount@%k.service"
+KERNEL=="mmcblk0p[0-9]]", ACTION=="remove", RUN+="/bin/systemctl stop media-mount@%k.service"
+KERNEL=="sd[a-z][0-9]", SUBSYSTEMS=="usb", ACTION=="add", RUN+="/bin/systemctl start media-mount@%k.service"
+KERNEL=="sd[a-z][0-9]", SUBSYSTEMS=="usb", ACTION=="remove", RUN+="/bin/systemctl stop media-mount@%k.service"

--- a/media-mount@.service
+++ b/media-mount@.service
@@ -1,0 +1,11 @@
+# From https://serverfault.com/a/767079
+# Modified from SteamOS 3 sdcard-mount@.service
+
+[Unit]
+Description=Mount removable media on %i
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/lib/media-support/mount-media.sh add %i
+ExecStop=/usr/lib/media-support/mount-media.sh remove %i

--- a/media-support/format-media.sh
+++ b/media-support/format-media.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Modified from SteamOS 3 format-sdcard.sh
+
+set -e
+MEDIA=$1
+PART=${MEDIA}1
+
+if [[ -e /dev/$MEDIA ]]
+then
+  # Stop the service to remove the drive from steam. 
+  systemctl stop media-mount@${PART}.service
+  
+  # Create the new filesystem.
+  parted --script /dev/${MEDIA} mklabel gpt mkpart primary 0% 100%
+  sync
+  mkfs.ext4 -m 0 -O casefold -F /dev/${PART}
+  sync
+
+  # Initialize a steam library.
+  /usr/lib/media-support/init-media.sh ${PART}
+  systemctl start media-mount@${PART}.service
+  echo "Format complete"
+  exit 0
+fi
+
+exit 1

--- a/media-support/init-media.sh
+++ b/media-support/init-media.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Intantiate file for tracking, if needed.
+FILE="/etc/removable-libraries"
+PART=$1
+
+if [[ ! -f "${FILE}" ]]; then
+    echo "Creating $FILE"
+    touch ${FILE}
+fi
+
+# Mount service checks for UUID before adding the drive to steam.
+echo "Initializing steam library."
+PART_UUID=$(blkid -o value -s UUID /dev/${PART})
+grep -qxF ${PART_UUID} ${FILE} || echo ${PART_UUID} >> ${FILE}

--- a/media-support/mount-media.sh
+++ b/media-support/mount-media.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+# Originally from https://serverfault.com/a/767079
+# Modified from SteamOS 3 sdcard-mount.sh
+
+# This script is called from our systemd unit file to mount or unmount
+# a USB drive.
+
+usage()
+{
+    echo "Usage: $0 {add|remove} device_name (e.g. sdb1)"
+    exit 1
+}
+
+if [[ $# -ne 2 ]]; then
+    usage
+fi
+
+ACTION=$1
+DEVBASE=$2
+DEVICE="/dev/${DEVBASE}"
+
+# See if this drive is already mounted, and if so where
+MOUNT_POINT=$(/bin/mount | /bin/grep ${DEVICE} | /usr/bin/awk '{ print $3 }')
+
+# See if this device has been initialized
+PART_UUID=$(blkid -o value -s UUID ${DEVICE})
+FILE="/etc/removable-libraries"
+if [[ -e $(grep -L "$PART_UUID" $FILE) ]]; then
+    echo "Device $DEVICE has not been initialized. Exiting."
+    exit 1
+fi
+
+# From https://gist.github.com/HazCod/da9ec610c3d50ebff7dd5e7cac76de05
+urlencode()
+{
+    [ -z "$1" ] || echo -n "$@" | hexdump -v -e '/1 "%02x"' | sed 's/\(..\)/%\1/g'
+}
+
+do_mount()
+{
+    if [[ -n ${MOUNT_POINT} ]]; then
+        echo "Warning: ${DEVICE} is already mounted at ${MOUNT_POINT}"
+        exit 1
+    fi
+
+    # Get info for this drive: $ID_FS_LABEL, $ID_FS_UUID, and $ID_FS_TYPE
+    eval $(/sbin/blkid -o udev ${DEVICE})
+
+    # Figure out a mount point to use
+    LABEL=${ID_FS_LABEL}
+    if [[ -z "${LABEL}" ]]; then
+        LABEL=${DEVBASE}
+    elif /bin/grep -q " /run/media/${LABEL} " /etc/mtab; then
+        # Already in use, make a unique one
+        LABEL+="-${DEVBASE}"
+    fi
+    MOUNT_POINT="/run/media/${LABEL}"
+
+    echo "Mount point: ${MOUNT_POINT}"
+
+    /bin/mkdir -p ${MOUNT_POINT}
+
+    # Global mount options
+    OPTS="rw,noatime"
+
+    # File system type specific mount options
+    #if [[ ${ID_FS_TYPE} == "vfat" ]]; then
+    #    OPTS+=",users,gid=100,umask=000,shortname=mixed,utf8=1,flush"
+    #fi
+
+    # We need symlinks for Steam for now, so only automount ext4 as that'll Steam will format right now
+    if [[ ${ID_FS_TYPE} != "ext4" ]]; then
+      exit 1
+    fi
+
+    if ! /bin/mount -o ${OPTS} ${DEVICE} ${MOUNT_POINT}; then
+        echo "Error mounting ${DEVICE} (status = $?)"
+        /bin/rmdir ${MOUNT_POINT}
+        exit 1
+    fi
+
+    chown 1000:1000 ${MOUNT_POINT}
+
+    echo "**** Mounted ${DEVICE} at ${MOUNT_POINT} ****"
+
+    url=$(urlencode ${MOUNT_POINT})
+
+    # If Steam is running, notify it
+    if pgrep -x "steam" > /dev/null; then
+        # TODO use -ifrunning and check return value - if there was a steam process and it returns -1, the message wasn't sent
+        # need to retry until either steam process is gone or -ifrunning returns 0, or timeout i guess
+        systemd-run -M 1000@ --user --collect --wait sh -c "./.steam/root/ubuntu12_32/steam steam://addlibraryfolder/${url@Q}"
+    fi
+}
+
+do_unmount()
+{
+    url=$(urlencode ${MOUNT_POINT})
+
+    # If Steam is running, notify it
+    if pgrep -x "steam" > /dev/null; then
+        # TODO use -ifrunning and check return value - if there was a steam process and it returns -1, the message wasn't sent
+        # need to retry until either steam process is gone or -ifrunning returns 0, or timeout i guess
+        systemd-run -M 1000@ --user --collect --wait sh -c "./.steam/root/ubuntu12_32/steam steam://removelibraryfolder/${url@Q}"
+    fi
+
+    if [[ -z ${MOUNT_POINT} ]]; then
+        echo "Warning: ${DEVICE} is not mounted"
+    else
+        /bin/umount -l ${DEVICE}
+        echo "**** Unmounted ${DEVICE}"
+    fi
+
+    # Delete all empty dirs in /media that aren't being used as mount
+    # points. This is kind of overkill, but if the drive was unmounted
+    # prior to removal we no longer know its mount point, and we don't
+    # want to leave it orphaned...
+    for f in /run/media/* ; do
+        if [[ -n $(/usr/bin/find "$f" -maxdepth 0 -type d -empty) ]]; then
+            if ! /bin/grep -q " $f " /etc/mtab; then
+                echo "**** Removing mount point $f"
+                /bin/rmdir "$f"
+            fi
+        fi
+    done
+}
+
+case "${ACTION}" in
+    add)
+        do_mount
+        ;;
+    remove)
+        do_unmount
+        ;;
+    *)
+        usage
+        ;;
+esac
+

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
              ],
 
     data_files=[
+        ('lib/media-support', glob('media-support/*')),
         ('share/chimera/images', glob('images/*.png')),
         ('share/chimera/images/flathub', glob('images/flathub/*.png')),
         ('share/chimera/views', glob('views/*.tpl')),


### PR DESCRIPTION
- Adds format-media.sh, init-media.sh, and mount-media.sh to
initialize a drive as a steam library.
- format-media.sh will create a new filesystem (uses entire disk)
- init-media.sh will log the drive UUID as an initialized device.
- media-mount.sh will verify a device is initialized, mount, and
then add the device as a steam library.
- Adds 99-media-mount.rules and media-mount@.service to handle hot
plugging initialized devices.
- Usage:
```format-media.sh <device>``` e.g. sda
```init-media.sh <partition>``` e.g. sda1
```mount-media.sh add|remove <partion>``` e.g. add sda1