### PR TITLE
Remove streaming stuff

### DIFF
--- a/chimera_app/server.py
+++ b/chimera_app/server.py
@@ -575,9 +575,9 @@ def emulators_yuzu():
     try:
         subprocess.Popen(["/usr/bin/yuzu"])
     finally:
-        redirect('/emulators')        
-        
-        
+        redirect('/emulators')
+
+
 @route('/actions/steam/overlay')
 @authenticate
 def steam_overlay():
@@ -600,10 +600,8 @@ def mangohud():
 @route('/streaming')
 @authenticate
 def streaming_control():
-    is_streaming = STREAMING_HANDLER.is_streaming()
     is_recording = STREAMING_HANDLER.is_recording()
     return template('streaming_control.tpl',
-                    streaming=is_streaming,
                     recording=is_recording)
 
 
@@ -708,20 +706,6 @@ def streaming_remove_acodec(acodec_id):
         current_acodec = ''
     SETTINGS_HANDLER.set_setting("ffmpeg_acodec", current_acodec)
     redirect('/streaming/config')
-
-
-@route('/streaming/net/start')
-@authenticate
-def streaming_net_start():
-    STREAMING_HANDLER.stream_to_lan()
-    return template('success.tpl')
-
-
-@route('/streaming/net/stop')
-@authenticate
-def streaming_stop():
-    STREAMING_HANDLER.stop_stream()
-    return template('success.tpl')
 
 
 @route('/record/start')

--- a/chimera_app/streaming.py
+++ b/chimera_app/streaming.py
@@ -1,5 +1,4 @@
 from shlex import split
-from time import strftime
 from os.path import expanduser
 from subprocess import Popen
 from subprocess import TimeoutExpired
@@ -10,26 +9,7 @@ class StreamServer:
 
     def __init__(self, settings_handler):
         self.settings = settings_handler
-        self._sls = None
         self._ffmpeg = None
-
-    def __generate_sls_conf(self):
-        pass
-
-    def __start_sls(self):
-        sls_conf_file = self.settings.get_setting("sls_conf_file")
-        if self._sls is None:
-            self._sls = Popen(['sls', '-c', sls_conf_file])
-        else:
-            raise(Exception("Error starting SLS: Already started"))
-
-    def __stop_sls(self):
-        self._sls.terminate()
-        try:
-            self._sls.wait(5)
-        except TimeoutExpired:
-            self._sls.kill()
-        self._sls = None
 
     def __start_ffmpeg(self, local=False):
         recordings_dir = self.settings.get_setting("recordings_dir")
@@ -38,15 +18,8 @@ class StreamServer:
         INPUTS = self.settings.get_setting("ffmpeg_inputs")
         VCODEC = self.settings.get_setting("ffmpeg_vcodec")
         ACODEC = self.settings.get_setting("ffmpeg_acodec")
-
-        if local:
-            OUTPUT_FORMAT = "-f matroska"
-            STREAM = "screen_" + \
-                str(time.strftime("%Y%m%d_%H%M%S")) + \
-                ".mkv"
-        else:
-            OUTPUT_FORMAT = "-f mpegts -flush_packets 0"
-            STREAM = '"srt://localhost:8080?streamid=uplive.chimeraos/live/stream"'
+        OUTPUT_FORMAT = "-f matroska"
+        STREAM = "screen_" + str(time.strftime("%Y%m%d_%H%M%S")) + ".mkv"
 
         # Build the ffmpeg command line
         cmd = ["ffmpeg"]
@@ -62,7 +35,7 @@ class StreamServer:
         print(args)
         if self._ffmpeg is None:
             self._ffmpeg = Popen(args,
-                                    cwd=expanduser(recordings_dir))
+                                 cwd=expanduser(recordings_dir))
         else:
             raise(Exception("Error starting FFMpeg: Already started"))
 
@@ -74,14 +47,6 @@ class StreamServer:
             self._ffmpeg.kill()
         self._ffmpeg = None
 
-    def stream_to_lan(self):
-        self.__start_sls()
-        self.__start_ffmpeg()
-
-    def stop_stream(self):
-        self.__stop_ffmpeg()
-        self.__stop_sls()
-
     def record_screen(self):
         self.__start_ffmpeg(local=True)
 
@@ -90,6 +55,3 @@ class StreamServer:
 
     def is_recording(self):
         return True if (self._ffmpeg and not self._sls) else False
-
-    def is_streaming(self):
-        return True if (self._ffmpeg and self._sls) else False

--- a/views/streaming_control.tpl
+++ b/views/streaming_control.tpl
@@ -1,21 +1,12 @@
 % rebase('base.tpl')
 <body>
-  % if streaming:
-  <div class="img-container">
-    <a href="/streaming/net/stop"><img src="/images/stop.png" alt="Stop Streaming"></a>
-  </div>
-  %end
   % if recording:
   <div class="img-container">
     <a href="/record/stop"><img src="/images/stop.png" alt="Stop Recording"></a>
   </div>
-  %end
-  % if not (recording or streaming):
+  % else:
   <div class="img-container">
     <a href="/record/start"><img src="/images/record.png" alt="Start Recording"></a>
-  </div>
-  <div class="img-container">
-    <a href="/streaming/net/start"><img src="/images/stream.png" alt="Start Streaming on LAN"></a>
   </div>
   <form action="/streaming/config">
     <button>Configure FFmpeg</button>


### PR DESCRIPTION
SRS server is failing to build and seems like an abandoned project. Current users can start a podman container like [the one described here](https://linderud.dev/blog/streaming-the-steam-deck-to-obs/) as an elegant solution to the same problem. Recording stuff still remains for ffmpeg but wont work on gamepadUI or gamescope sessions.