### PR TITLE
Remove individual joystick init

### DIFF
--- a/bin/chimera-authenticator
+++ b/bin/chimera-authenticator
@@ -27,8 +27,6 @@ large_font = pygame.font.SysFont('dejavusans', font_size*2, bold=True)
 # Setup joystick
 pygame.joystick.init()
 joysticks = [pygame.joystick.Joystick(x) for x in range(pygame.joystick.get_count())]
-for joystick in joysticks:
-    joystick.init()
 
 # Create text to display on screen
 password_text = large_font.render(password, True, Color.TEXT)


### PR DESCRIPTION
joystick.init occasionally causes a crash of chimmera. This is because the list occasionally places a physical device ahead of a virtual device (such as steam input or HandyGCCS) and the init function takes over control of the joystick as such a low level the virtual devices are despawned, but remain in the list currently iterating. Through testing I was able to identify that initializing the pygame joystick library is sufficient to scrape for system button events. This PR prevents the crash condition while preserving the functionality.