### PR TITLE
Show Titles for Flathub Apps

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -51,6 +51,15 @@ p.placeholder {
     background-color: #3268a8;
 }
 
+.app-container {
+    display: inline-block;
+}
+
+.app-container .title {
+    margin: 0;
+    padding: 0;
+}
+
 .img-container {
     position: relative;
     display: inline-block;

--- a/views/custom.tpl
+++ b/views/custom.tpl
@@ -10,11 +10,15 @@
 
 % from urllib.parse import quote
 % for app in app_list:
-<div class="img-container">
-    <a href="/library/{{ platform }}/edit/{{ app.content_id }}">
-        <img src="{{ app.image_url }}" alt="{{ app.name }}" title="{{ app.get('status_icon') }} {{ app.name }}">
-    </a>
+<div class="app-container">
+    <div class="img-container">
+        <a href="/library/{{ platform }}/edit/{{ app.content_id }}">
+            <img src="{{ app.image_url }}" alt="{{ app.name }}" title="{{ app.get('status_icon') }} {{ app.name }}">
+        </a>
+    </div>
+    <p class="title">{{app.name}}</p>
 </div>
+
 % end
 
 % if not showAll and not isInstalledOverview:


### PR DESCRIPTION
This adds titles to the Flathub app listings.

## Why?
When adding Flathub software, the only thing that shows is the app icon. It's not clear what any of the software is unless you are familiar with its icon. Additionally, you can not search the list.

By adding titles to the listings, the options are more descriptive, and you can use Find in Page in the browser to find what you are looking for.

## Screenshot

<img width="1469" alt="Screenshot 2023-03-01 at 11 13 29 AM" src="https://user-images.githubusercontent.com/260/222200582-b1ce3f79-b762-4065-92c3-4cf70ff32d4f.png">
