### PR TITLE
Add timeouts to all requests.get() calls

### DIFF
--- a/chimera_app/data.py
+++ b/chimera_app/data.py
@@ -54,7 +54,7 @@ class Downloader():
         """
         api_url = ('https://api.github.com/repos/chimeraos/'
                    'chimera-data/branches')
-        resp = requests.get(api_url, timeout=1)
+        resp = requests.get(api_url, timeout=10)
         db_path = os.path.join(self.db_path, "branches.json")
         ensure_directory_for_file(db_path)
         branches = resp.json()

--- a/chimera_app/data.py
+++ b/chimera_app/data.py
@@ -54,7 +54,7 @@ class Downloader():
         """
         api_url = ('https://api.github.com/repos/chimeraos/'
                    'chimera-data/branches')
-        resp = requests.get(api_url)
+        resp = requests.get(api_url, timeout=1)
         db_path = os.path.join(self.db_path, "branches.json")
         ensure_directory_for_file(db_path)
         branches = resp.json()

--- a/chimera_app/platforms/flathub.py
+++ b/chimera_app/platforms/flathub.py
@@ -49,7 +49,7 @@ class Flathub(StorePlatform):
 
     def _get_all_content(self):
         applications = []
-        api_response = requests.get(self.__api_url, timeout=5)
+        api_response = requests.get(self.__api_url, timeout=20)
         if api_response.status_code == requests.codes.ok:
             installed_list = self.__get_installed_list()
             for entry in api_response.json():

--- a/chimera_app/platforms/flathub.py
+++ b/chimera_app/platforms/flathub.py
@@ -49,7 +49,7 @@ class Flathub(StorePlatform):
 
     def _get_all_content(self):
         applications = []
-        api_response = requests.get(self.__api_url)
+        api_response = requests.get(self.__api_url, timeout=5)
         if api_response.status_code == requests.codes.ok:
             installed_list = self.__get_installed_list()
             for entry in api_response.json():

--- a/chimera_app/server.py
+++ b/chimera_app/server.py
@@ -268,7 +268,7 @@ def shortcut_create():
         ext = get_ext(image_urls[img_type])
         image_paths[img_type] = os.path.join(BANNER_DIR, img_type, platform, f"{name}{ext}")
         ensure_directory_for_file(image_paths[img_type])
-        download = requests.get(image_urls[img_type])
+        download = requests.get(image_urls[img_type], timeout=5)
         with open(image_paths[img_type], "wb") as image_file:
             image_file.write(download.content)
 
@@ -324,7 +324,7 @@ def shortcut_update():
         ext = get_ext(image_urls[img_type])
         image_paths[img_type] = os.path.join(BANNER_DIR, img_type, platform, f"{name}{ext}")
         ensure_directory_for_file(image_paths[img_type])
-        download = requests.get(image_urls[img_type])
+        download = requests.get(image_urls[img_type], timeout=5)
         with open(image_paths[img_type], "wb") as image_file:
             image_file.write(download.content)
 

--- a/chimera_app/server.py
+++ b/chimera_app/server.py
@@ -268,7 +268,7 @@ def shortcut_create():
         ext = get_ext(image_urls[img_type])
         image_paths[img_type] = os.path.join(BANNER_DIR, img_type, platform, f"{name}{ext}")
         ensure_directory_for_file(image_paths[img_type])
-        download = requests.get(image_urls[img_type], timeout=5)
+        download = requests.get(image_urls[img_type], timeout=20)
         with open(image_paths[img_type], "wb") as image_file:
             image_file.write(download.content)
 
@@ -324,7 +324,7 @@ def shortcut_update():
         ext = get_ext(image_urls[img_type])
         image_paths[img_type] = os.path.join(BANNER_DIR, img_type, platform, f"{name}{ext}")
         ensure_directory_for_file(image_paths[img_type])
-        download = requests.get(image_urls[img_type], timeout=5)
+        download = requests.get(image_urls[img_type], timeout=20)
         with open(image_paths[img_type], "wb") as image_file:
             image_file.write(download.content)
 

--- a/chimera_app/steamgrid/steamgrid.py
+++ b/chimera_app/steamgrid/steamgrid.py
@@ -33,4 +33,4 @@ class Steamgrid:
         headers = {
             'Authorization': "Bearer {}".format(self.__api_key)
         }
-        return requests.get(url, headers=headers, timeout=5)
+        return requests.get(url, headers=headers, timeout=20)

--- a/chimera_app/steamgrid/steamgrid.py
+++ b/chimera_app/steamgrid/steamgrid.py
@@ -33,4 +33,4 @@ class Steamgrid:
         headers = {
             'Authorization': "Bearer {}".format(self.__api_key)
         }
-        return requests.get(url, headers=headers)
+        return requests.get(url, headers=headers, timeout=5)


### PR DESCRIPTION
Some of out get calls are not properly set up. That could lead to hangs of the service or the CLI application if no response is get. This allows for fast fail. The default is set to 20 seconds and for API calls to 10, roughly.