### PR TITLE
system-info: Gracefully handle pulsemixer being unavailable

### DIFF
--- a/bin/system-info
+++ b/bin/system-info
@@ -1,6 +1,10 @@
 #!/bin/bash
 export LC_ALL=C
 
+function icanuse () {
+    test -x "$(command -v $1)"
+}
+
 # Scaffold some hefty guard rails around ensuring DISPLAY works
 if [ -z "${DISPLAY}" ]; then
     # Hunt for an accessible DISPLAY
@@ -25,7 +29,7 @@ fi
 # Dump data
 for CMD in glxinfo xdpyinfo xrandr; do
     # NOTE: xdpyinfo is not currently available in ChimeraOS; so we check availability
-    if [ -x "$(command -v ${CMD})" ]; then
+    if icanuse $CMD; then
         if ! "${CMD}" > "/tmp/${CMD}.txt"; then
             echo "ERROR! ${CMD} failed."
             exit 1
@@ -120,7 +124,15 @@ fi
 PRIMARY_VRAM=$(grep "Dedicated video memory:" /tmp/glxinfo.txt | cut -d':' -f2 | sed 's/^ *//')
 
 # Sound card:
-AUDIO_DEVICE=$(pulsemixer --list-sinks | grep Default | cut -d',' -f2 | sed 's/ Name: //')
+if icanuse pulsemixer; then
+    AUDIO_DEVICE=$(pulsemixer --list-sinks | grep Default | cut -d',' -f2 | sed 's/ Name: //')
+elif icanuse pw-dump && icanuse pactl && icanuse jq; then
+    AUDIO_DEVICE_ALSA=$(pactl get-default-sink)
+    AUDIO_DEVICE_QUERY=".[] | select(.type == \"PipeWire:Interface:Node\") | select(.info.props.\"node.name\" == \"$(pactl get-default-sink)\") | .info.props.\"node.nick\""
+    AUDIO_DEVICE=$(pw-dump | jq --raw-output "$AUDIO_DEVICE_QUERY")
+else
+    AUDIO_DEVICE="Unknown"
+fi
 
 # Memory:
 RAM=$(grep MemTotal /proc/meminfo | tr -s ' ' | cut -d' ' -f2)

--- a/bin/system-info
+++ b/bin/system-info
@@ -127,7 +127,6 @@ PRIMARY_VRAM=$(grep "Dedicated video memory:" /tmp/glxinfo.txt | cut -d':' -f2 |
 if icanuse pulsemixer; then
     AUDIO_DEVICE=$(pulsemixer --list-sinks | grep Default | cut -d',' -f2 | sed 's/ Name: //')
 elif icanuse pw-dump && icanuse pactl && icanuse jq; then
-    AUDIO_DEVICE_ALSA=$(pactl get-default-sink)
     AUDIO_DEVICE_QUERY=".[] | select(.type == \"PipeWire:Interface:Node\") | select(.info.props.\"node.name\" == \"$(pactl get-default-sink)\") | .info.props.\"node.nick\""
     AUDIO_DEVICE=$(pw-dump | jq --raw-output "$AUDIO_DEVICE_QUERY")
 else


### PR DESCRIPTION
For context, this was motivated by me wanting to use `system-info` outside of Chimera or ChimeraOS (specifically, on my openSUSE Tumbleweed desktop; Steam's built-in "System Information" tool keeps crashing X11 on my machine for some reason, and using this script was much easier than trying to troubleshoot what's probably some weird driver issue).

Long story short: if pulsemixer ain't installed, then this provides an alternate way to get an audio device name (using `pactl`, `pw-dump`, and `jq`) - and if *that* fails, then it'll at least be populated with "Unknown" rather than being totally empty.

I also moved the `[ -x "$(command -v ${CMD})" ]` logic (from the `glxinfo`/`xdpyinfo`/`xrandr` checks) into a dedicated `icanuse` function, since I needed that logic for the `pulsemixer`/`pactl`/`pw-dump`/`jq` checks anyway and having a proper function cut down on the resulting repetitiveness.