### PR TITLE
Flathub Titles Take 2

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -51,6 +51,20 @@ p.placeholder {
     background-color: #3268a8;
 }
 
+.app-container {
+    display: inline-block;
+ }
+
+ .app-container .title {
+    margin: 0 16px;
+    padding: 0;
+    text-align: center;
+    width: 248px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+ }
+
 .img-container {
     position: relative;
     display: inline-block;

--- a/public/style.css
+++ b/public/style.css
@@ -53,6 +53,7 @@ p.placeholder {
 
 .app-container {
     display: inline-block;
+    margin-bottom: 20px;
  }
 
  .app-container .title {
@@ -68,7 +69,7 @@ p.placeholder {
 .img-container {
     position: relative;
     display: inline-block;
-    margin: 16px;
+    margin: 8px 16px;
     padding: 0px;
     height: 116px;
     width: 248px;

--- a/views/custom.tpl
+++ b/views/custom.tpl
@@ -10,10 +10,13 @@
 
 % from urllib.parse import quote
 % for app in app_list:
-<div class="img-container">
-    <a href="/library/{{ platform }}/edit/{{ app.content_id }}">
-        <img src="{{ app.image_url }}" alt="{{ app.name }}" title="{{ app.get('status_icon') }} {{ app.name }}">
-    </a>
+<div class="app-container">
+     <div class="img-container">
+         <a href="/library/{{ platform }}/edit/{{ app.content_id }}">
+             <img src="{{ app.image_url }}" alt="{{ app.name }}" title="{{ app.get('status_icon') }} {{ app.name }}">
+         </a>
+     </div>
+     <p class="title">{{app.name}}</p>
 </div>
 % end
 


### PR DESCRIPTION
This is a second attempt at resolving #272. 

## Why?

When adding Flathub software, the only thing that shows is the app icon. It's not clear what any of the software is unless you are familiar with its icon. Additionally, you can not search the list.

By adding titles to the listings, the options are more descriptive, and you can use Find in Page in the browser to find what you are looking for.

## What's different now?


There were 2 reasons the [original](https://github.com/ChimeraOS/chimera/pull/263) change was reverted:

1. Listings were showing in a single column
2. Long titles were disturbing alignment

These have both been resolved via:

1. This was an artifact of cached CSS. After doing a full reload via `Shift + refresh`, the new CSS was fully loading and everything is aligned correctly.
2. Titles have been truncated to not wrap or overflow. This has no effect on being able to search in page, as the truncation was done with CSS, so the full title is still searchable.

## Screenshot

![image](https://user-images.githubusercontent.com/260/231772902-43f97779-c433-4aa8-8b02-6ce8010c113c.png)

