### PR TITLE
Ensure Add Buttons Are Aligned

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -64,6 +64,7 @@ p.placeholder {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    font-size: 0.7em;
  }
 
 .img-container {

--- a/views/custom.tpl
+++ b/views/custom.tpl
@@ -1,10 +1,13 @@
 % rebase('base.tpl')
 
 % if isInstalledOverview:
-<div class="img-container">
-    <a href="/library/{{ platform }}/new">
-        <img src="/images/add.png" alt="Add new shortcut" title="Add new shortcut">
-    </a>
+<div class="app-container">
+    <div class="img-container">
+        <a href="/library/{{ platform }}/new">
+            <img src="/images/add.png" alt="Add new shortcut" title="Add new shortcut">
+        </a>
+    </div>
+     <p class="title">&nbsp;</p>
 </div>
 % end
 


### PR DESCRIPTION
This pull:

* adds a blank title to the add button to ensure it's aligned correctly with the other cards.
* lowers the font size of the titles

## Screenshots

<img width="804" alt="image" src="https://user-images.githubusercontent.com/260/232448556-11d1e3bf-6208-4f92-a4e3-5029e464df6a.png">

<img width="1212" alt="image" src="https://user-images.githubusercontent.com/260/232448573-f5392070-45c7-4570-a790-67ff5cba386c.png">
