### PR TITLE
Persist User Config For wii.cfg

### DIFF
--- a/bin/launcher
+++ b/bin/launcher
@@ -45,8 +45,7 @@ fi
 
 if [ "${RETRO_CORE}" == "dolphin" ]; then
 	mkdir -p ${CONFIG_HOME}/retroarch/config/remaps/dolphin-emu
-	rm -f ${CONFIG_HOME}/retroarch/config/remaps/dolphin-emu/dolphin-emu.rmp
-	ln -s ${CORE_CONFIG} ${CONFIG_HOME}/retroarch/config/remaps/dolphin-emu/dolphin-emu.rmp
+	cp -f ${CORE_CONFIG} ${CONFIG_HOME}/retroarch/config/remaps/dolphin-emu/dolphin-emu.rmp
 fi
 
 retroarch \


### PR DESCRIPTION
The user-configured wii.cfg is overridden by retroarch when linking it to the controller remap folder. Copy is a more suitable operation in this here.

Closes #278