### PR TITLE
docs: SSH documentation in README and change to web page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 venv/
 .pybuild
 *.egg-info
+*.code-workspace

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+    "default": true,
+    "MD013": false,
+    "MD041": false
+}

--- a/README.md
+++ b/README.md
@@ -1,37 +1,42 @@
 ## What is it?
+
 Chimera is a web app for remotely installing non-Steam software to your Linux based couch gaming system. It was primarily developed for ChimeraOS.
 
 ## Features
 
- - install games from GOG, Epic Games Store, and Flathub
- - upload ROMs for supported console emulators
- - quick actions
-   - adjust audio volume
-   - adjust TDP of supported devices
-   - load/save emulator state
-   - restart steam
-   - suspend/reboot/power off
- - built-in FTP server
- - enable SSH access
+- install games from GOG, Epic Games Store, and Flathub
+- upload ROMs for supported console emulators
+- quick actions
+  - adjust audio volume
+  - adjust TDP of supported devices
+  - load/save emulator state
+  - restart steam
+  - suspend/reboot/power off
+- built-in FTP server
+- enable SSH access
 
 ## Installation
+
 On Arch Linux install the `chimera` package from the AUR. On ChimeraOS the package is pre-installed
 
 After installing the `chimera` package, you must run the following commands to enable the web interface and then restart your system:
-```
+
+```bash
     systemctl --user enable chimera.service
     sudo systemctl enable chimera-proxy.service
     sudo systemctl enable chimera-proxy.socket
 ```
 
 To have game patches be applied, you must also run the following command
-```
+
+```bash
    systemctl --user enable steam-patch
 ```
 
 ## Usage
 
 ### Web interface
+
 You can connect to Chimera on ChimeraOS by opening a browser on another computer and entering `chimeraos.local:8844`. If that does not work, then determine the IP address of your ChimeraOS system by looking at the network settings and enter it directly into your browser along with the port number, for example: `192.168.10.120:8844`.
 
 After installing any app, you must restart Steam for the newly installed application or game to appear in the Steam Big Picture UI.
@@ -39,25 +44,31 @@ After installing any app, you must restart Steam for the newly installed applica
 To restart Steam you can open the menu, click on "Actions", then select "Restart Steam".
 
 ### Command line interface
+
 If you use ChimeraOS or use `gamescope-session` and have `chimera` installed, the required commands to apply game tweaks and shortcuts to Steam will run automatically when the Steam session starts.
 
 Otherwise, you will need to run `chimera --update` and `chimera --tweaks` while Steam is not running because any changes applied while Steam is running will be overwritten by Steam.
 
 ## Configuration
+
 For console platforms, Chimera creates shortcuts in Steam which launch each game with RetroArch. The default RetroArch configuration files are located under `/usr/share/chimera/config/`. You can override the default configuration by creating corresponding files under `~/.config/chimera/`.
 
 ## Screenshots
 
-### Library page 
+### Library page
+
 ![Library](screenshots/platforms.png?raw=true)
 
 ### Flathub library page
+
 ![Flathub](screenshots/flathub.png?raw=true)
 
 ### Flathub game page
+
 ![Flathub Game](screenshots/flathub-game.png?raw=true)
 
 ### Actions page
+
 ![Actions](screenshots/actions.png?raw=true)
 
 ## Feature Details
@@ -67,31 +78,35 @@ For console platforms, Chimera creates shortcuts in Steam which launch each game
 GOG, Epic, and Flathub applications and games are evaluated for compatibility and assigned a rating of "Unsupported", "Playable", and "Verified", reflecting the Steam Deck ratings. You can contribute to these ratings by submitting a PR against [chimera-data](https://github.com/chimeraos/chimera-data) or commenting in the `compatibility-reports` channel on the [ChimeraOS Discord](https://discord.gg/fKsUbrt).
 
 ### Install Flathub apps
+
 You can install any application on Flathub by going to `Library`, then selecting `Flathub`.
 
-Chimera also looks in `~/.local/share/chimera/banners/flathub/` for a list of additionally allowed Flathub applications. Just add a PNG or JPEG image of size 460x215 or 920x430 with the Flathub app id as the file name under that directory. The Flathub app id can be obtained from the last part of the URL of the Flathub page for the application. For example, the id for Minecraft is `com.mojang.Minecraft`.
+Chimera also looks in `~/.local/share/chimera/banners/flathub/` for a list of additionally allowed Flathub applications. Just add a PNG or JPEG image of size 460x215 or 920x430 with the Flathub app ID as the file name under that directory. The Flathub app ID can be obtained from the last part of the URL of the Flathub page for the application. For example, the ID for Minecraft is `com.mojang.Minecraft`.
 
-If the application works well please create a new issue with the app id and grid image so it can be added to the set of installable default apps.
+If the application works well please create a new issue with the app ID and grid image so it can be added to the set of installable default apps.
 
 ### Install games from the Epic Games Store
+
 After logging in to your Epic account, you can download and install any of your games from the Epic Games Store.
 
 Games are automatically started with Proton. Not all games will work.
 
 ### Install games from GOG
+
 After logging in to your GOG account, you can download and install any of your games from GOG.
 
 GOG support currently has a few limitations:
- - No support for Dosbox based games
- - Installation progress is not displayed
- - Games cannot be updated directly
 
+- No support for Dosbox based games
+- Installation progress is not displayed
+- Games cannot be updated directly
 
 ### Upload ROMs
 
-You can upload ROMs and banner images to Chimera and they will be added to Steam. The emulators are pre-configured and ready to play out of the box with almost any controller.
+You can upload ROMs and banner images to Chimera, and they will be added to Steam. The emulators are pre-configured and ready to play out of the box with almost any controller.
 
 The following platforms are currently supported:
+
 - 32X (requires BIOS file)
 - 3DO (requires BIOS file)
 - Arcade
@@ -127,29 +142,59 @@ CHD files can be created easily from cue/bin format using the `chdman` tool.
 
 BIOS files can be uploaded the same as games. However, the name of the shortcut should reflect the name of the file that the emulator is looking for without the file extension.
 
-Also, select the "Hide" option so the BIOS file is not shown in Steam along with other games.
+Also, select the "Hide" option, so the BIOS file is not shown in Steam along with other games.
 
+### System
+
+You can access some system settings via the "System" page, reachable at <http://chimeraos.local:8844/system>.
+
+#### Storage
+
+TBD
+
+#### Logging in
+
+Every time you use the web application, you'll be prompted for a custom password which will be displayed by the system running ChimeraOS. If you want, you can change this behavior and configure a fixed password instead.
+
+#### SSH
+
+SSH allows you to access the command line of your ChimeraOS machine remotely.\
+You can add your public key by pasting it in the relevant field, then click on "Save" at the bottom of the page. If the operation is successful, you'll see your public key listed below the "Add public key" field once tha page reloads.
+
+**NOTE:** the application will only accept public keys that match the following criteria:
+
+- the key is made of _three_ components, space separated:
+  - the key type (e.g. ssh-rsa, ssh-ed25519, etc.)
+  - the base64-encoded key
+  - a comment
+- the key type starts with `ssh-`
 
 ## Command line details
+
 ### Data updater (chimera --update)
+
 This command updates the compatibility tool, tweaks and patch database from the [chimera-data](https://github.com/chimeraos/chimera-data) repo.
 
 ### Steam Compat Tools (chimera --compat)
+
 This command generates stub files for compatibility tools (currently various versions of Proton GE), which are then downloaded automatically when a game that utilizes the tool is first run.
 
 ### Steam Config (chimera --config)
+
 Configures Steam games according to the automatically downloaded tweaks database, or the local override file if found at `~/.config/steam-tweaks.yaml`.
 
 Extends Valve's Steam Play/Proton whitelist, specifying the compatibility tool, launch options and whether Steam Input is enabled on a per-game basis. Many games are already configured to work out of the box, with more being added over time. Please help by testing the games you own and submitting your configurations.
 
 #### Game tweak entry format
- - **compat_tool**: the compatibility tool to be used for the specified game, e.g. `proton_42`, `steamlinuxruntime`
- - **compat_config**: the configuration for the compatibility tool specified, e.g. for proton: `d9vk`, `noesync`, etc; see the [Proton docs](https://github.com/ValveSoftware/Proton#runtime-config-options) for the full list of available options
- - **launch_options**: the launch options to be used
- - **steam_input**: a value of `enabled` will force the use of Steam Input for the specified game
+
+- **compat_tool**: the compatibility tool to be used for the specified game, e.g. `proton_42`, `steamlinuxruntime`
+- **compat_config**: the configuration for the compatibility tool specified, e.g. for proton: `d9vk`, `noesync`, etc. see the [Proton docs](https://github.com/ValveSoftware/Proton#runtime-config-options) for the full list of available options
+- **launch_options**: the launch options to be used
+- **steam_input**: a value of `enabled` will force the use of Steam Input for the specified game
 
 #### Example entry
-```
+
+```yaml
 "321040":
   compat_tool: proton_411
   compat_config: noesync
@@ -157,13 +202,15 @@ Extends Valve's Steam Play/Proton whitelist, specifying the compatibility tool, 
   steam_input: enabled
 ```
 
-Each game is specified by its Steam app id. Note that the app id MUST be quoted.
+Each game is specified by its Steam app ID. Note that the app ID MUST be quoted.
 
 ### Steam Shortcuts (chimera --shortcuts)
+
 Reads one or more YAML formatted shortcut definition files stored under `~/.local/share/chimera/shortcuts/` and adds the shortcuts to all available Steam accounts.
 
 #### Single shortcut per file example
-```
+
+```yaml
 name: Firefox                   # name of the shortcut as it will appear in Steam (required)
 cmd: firefox                    # the command to execute (required)
 dir: /full/path/to/working/dir  # the directory from which to execute the command
@@ -171,7 +218,7 @@ params: github.com              # any parameters to invoke the command with
 banner: /path/to/image.png      # the horizontal banner image to use (460x215)
 poster: /path/to/image.png      # the vertical poster image to use (600x900)
 background: /path/to/image.png  # the background/hero image to use (1920x620)
-logo: /path/to/image.png        # the logo image to use (overlayed on top of background image)
+logo: /path/to/image.png        # the logo image to use (overlaid on top of background image)
 icon: firefox                   # small icon to show in Steam
 compat_tool: proton_9           # use the given compatibility tool, useful for running Windows executables
 compat_config: noesync          # use the given compatibility tool options
@@ -182,7 +229,8 @@ tags:                           # a list of tags to be assigned to the shortcut 
 ```
 
 #### Multiple shortcuts per file example
-```
+
+```yaml
 - name: Firefox
   cmd: firefox
   ...

--- a/views/settings.tpl
+++ b/views/settings.tpl
@@ -40,7 +40,8 @@
 
     <h4>SSH</h4>
     <hr>
-    SSH allows you to access the command line of this machine remotely. Once your SSH public key has been added, you can connect to this server with "ssh {{username}}@{{hostname}}".<br>
+    To access this machine remotely, add your public SSH key by pasting it in the field below, then click on "Save" at the bottom of the page. If the operation is successful, you'll see your public key appear below the "Add public key" field once tha page reloads. For more details, please refer to <a href="https://github.com/ChimeraOS/chimera/blob/master/README.md">the README file of the Github repository</a>.<br>
+    Once your SSH public key has been added, you can connect to this server with "ssh {{username}}@{{hostname}}".<br>
 
     <div class="label">Add public key</div>
     <input name="ssh_key"/>

--- a/views/settings.tpl
+++ b/views/settings.tpl
@@ -40,8 +40,8 @@
 
     <h4>SSH</h4>
     <hr>
-    To access this machine remotely, add your public SSH key by pasting it in the field below, then click on "Save" at the bottom of the page. If the operation is successful, you'll see your public key appear below the "Add public key" field once tha page reloads. For more details, please refer to <a href="https://github.com/ChimeraOS/chimera/blob/master/README.md">the README file of the Github repository</a>.<br>
-    Once your SSH public key has been added, you can connect to this server with "ssh {{username}}@{{hostname}}".<br>
+    SSH allows you to access the command line of this machine remotely. Once your SSH public key has been added, you can connect to this server with "ssh {{username}}@{{hostname}}". 
+    For more details, please refer to <a href="https://github.com/ChimeraOS/chimera/blob/master/README.md">the README file of the Github repository</a>.<br>
 
     <div class="label">Add public key</div>
     <input name="ssh_key"/>


### PR DESCRIPTION
Hi there!

I hope I am not overstepping any boundaries here. 😁

Here's a changelog:

- One big linting pass over the README.md file:
  - Markdown lint. Hence, the new `.markdownlint.json` file
  - LanguageTool lint
- New section to the README file regarding the “Settings” page
  - Add documentation regarding SSH keys and login password
  - Add heading for “Storage”, but I wouldn't really know what to write in there yet
- Change the SSH text in the HTML page,

Note that I did not test how the changes to the HTML page will render, as I didn't have an easy way to do so.

Cheers,